### PR TITLE
fix: Increase request timeout

### DIFF
--- a/apps/nsc-kernel/nsc.yaml
+++ b/apps/nsc-kernel/nsc.yaml
@@ -19,6 +19,8 @@ spec:
           image: networkservicemeshci/cmd-nsc:659e04e0
           imagePullPolicy: IfNotPresent
           env:
+            - name: NSM_REQUEST_TIMEOUT
+              value: 1m
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_NAME


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


## Issue


Our nses have expiration 1 min by default
Our nscs have request timeout 15 sec by default

It could produce a wrong situation in the suite testing:
1. the First test creates NSE
2. the First test is done NSE is deleted (but the entry from the registry is not deleted! It will be deleted after NSE expiration)
3. the Second test starts with NSE, NSC
4. NSC in the Second test trying to connect to NSE from the First test! 

If request timeout less than expiration from the first NSE then the test will fail due to NSC connect to died NSE.


## Motivation

This PR provides tmp fix.

The real fix of the issue described here: https://github.com/networkservicemesh/sdk/issues/666