### PR TITLE
use merge-me-action with retries instead of automerge-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,10 @@ jobs:
         run: |
           find . -type f ! -name '*.yaml' ! -name '*.yml' -exec git diff --exit-code origin/main -- {} +
       - name: Automerge nsmbot PR
-        uses: "pascalgn/automerge-action@v0.13.1"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        uses: ridedott/merge-me-action@master
+        with:
+          MAXIMUM_RETRIES: 10
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   update-dependent-repositories:
     strategy:
       matrix:


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

`automerge-action` requires labels to set. 

`merge-me-action ` uses 3 retries by default, so probably we could just increase the attempts count.