### PR TITLE
fix: add missed GITHUB_LOGIN for merge-me-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,9 @@ jobs:
       - name: Automerge nsmbot PR
         uses: ridedott/merge-me-action@master
         with:
-          MAXIMUM_RETRIES: 10
+          GITHUB_LOGIN: nsmbot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAXIMUM_RETRIES: 10
   update-dependent-repositories:
     strategy:
       matrix:


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

This PR Fixes: `Pull request created by nsmbot, not dependabot[bot], skipping.`