### PR TITLE
fix: deployments-k8s cannot update integration-tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Push update to the ${{ matrix.repository }}
         working-directory: ${{ github.workspace }}/src/github.com/networkservicemesh/${{ matrix.repository }}
         run: |
-          sed -r -i 's/(s\.Version =.*)/s.Version = "${{ steps.short-sha.outputs.sha }}"/g' extensions/base/suite.go
+          sed -r -i 's/(s\.checkout\.Version =.*)/s.checkout.Version = "${{ steps.short-sha.outputs.sha }}"/g' extensions/base/suite.go
           echo Starting to update repositotry ${{ matrix.repository }}
           git config --global user.email "nsmbot@networkservicmesh.io"
           git config --global user.name "NSMBot"


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

Previously we added with https://github.com/networkservicemesh/integration-tests/pull/285 prefetching.

Now we need to sync up `deployments-k8s` with `integration-tests`