### PR TITLE
Increase spire version

### DIFF
--- a/examples/spire/agent-daemonset.yaml
+++ b/examples/spire/agent-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.10.0
+          image: gcr.io/spiffe-io/spire-agent:0.12.1
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/examples/spire/server-statefulset.yaml
+++ b/examples/spire/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.10.0
+          image: gcr.io/spiffe-io/spire-server:0.12.1
           args:
             - -config
             - /run/spire/config/server.conf


### PR DESCRIPTION
Refers to #727.

Spire before 0.11.1 version have troubles with burstable class (networkservicemesh/networkservicemesh#2183), so we need to update it.