### PR TITLE
Getting correct admission-webhook

### DIFF
--- a/examples/features/dns/README.md
+++ b/examples/features/dns/README.md
@@ -11,7 +11,7 @@ Make sure that you have completed steps from [features](../)
 
 Note: Admission webhook is required and should be started at this moment.
 ```bash
-WH=$(kubectl get mutatingwebhookconfigurations --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+WH=$(kubectl get pods -l app=admission-webhook-k8s -n nsm-system --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
 kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 ```
 

--- a/examples/features/webhook/README.md
+++ b/examples/features/webhook/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [features](../)
 
 Note: Admission webhook is required and should be started at this moment.
 ```bash
-WH=$(kubectl get mutatingwebhookconfigurations --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+WH=$(kubectl get pods -l app=admission-webhook-k8s -n nsm-system --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
 kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 ```
 


### PR DESCRIPTION
Sometimes `mutatingwebhookconfigurations` returns list of webhooks - `nsm-system` and created by default by the cluster (e.g. `aks-webhook-admission-controller` for `AKS` cluster). 
We need only `nsm-system`

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>