### PR TITLE
Add wireguard examples

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -16,6 +16,10 @@ Contain basic setup for NSM that includes `nsmgr`, `forwarder-vpp`, `registry-k8
 - [Memif to VXLAN to Memif Connection](../use-cases/Memif2Vxlan2Memif)
 - [Kernel to VXLAN to Memif Connection](../use-cases/Kernel2Vxlan2Memif)
 - [Memif to VXLAN to Kernel Connection](../use-cases/Memif2Vxlan2Kernel)
+- [Kernel to Wireguard to Kernel Connection](../use-cases/Kernel2Wireguard2Kernel)
+- [Memif to Wireguard to Memif Connection](../use-cases/Memif2Wireguard2Memif)
+- [Kernel to Wireguard to Memif Connection](../use-cases/Kernel2Wireguard2Memif)
+- [Memif to Wireguard to Kernel Connection](../use-cases/Memif2Wireguard2Kernel)
 
 ## Run
 

--- a/examples/use-cases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Kernel/README.md
@@ -1,0 +1,135 @@
+# Test kernel to wireguard to kernel connection
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+NSC and NSE are using the `kernel` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [basic](../../basic) or [memory](../../memory) setup.
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-kernel
+- ../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: kernel://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-kernel -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+kubectl exec ${NSC} -n ${NAMESPACE} -- ping -c 4 172.16.1.100
+```
+
+Ping from NSE to NSC:
+```bash
+kubectl exec ${NSE} -n ${NAMESPACE} -- ping -c 4 172.16.1.101
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/use-cases/Kernel2Wireguard2Memif/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Memif/README.md
@@ -1,0 +1,138 @@
+# Test kernel to wireguard to memif
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+NSC is using the `kernel` mechanism to connect to its local forwarder.
+NSE is using the `memif` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [basic](../../basic) or [memory](../../memory) setup.
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-kernel
+- ../../../apps/nse-memif
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: kernel://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-memif -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+kubectl exec ${NSC} -n ${NAMESPACE} -- ping -c 4 172.16.1.100
+```
+
+Ping from NSE to NSC:
+```bash
+result=$(kubectl exec "${NSE}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.101 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/use-cases/Memif2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Memif2Wireguard2Kernel/README.md
@@ -1,0 +1,139 @@
+# Test memif to wireguard to kernel connection
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+
+NSC is using the `memif` mechanism to connect to its local forwarder.
+NSE is using the `kernel` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [basic](../../basic) or [memory](../../memory) setup.
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-memif
+- ../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: memif://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-memif -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-kernel -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+result=$(kubectl exec "${NSC}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.100 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+Ping from NSE to NSC:
+```bash
+kubectl exec ${NSE} -n ${NAMESPACE} -- ping -c 4 172.16.1.101
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/use-cases/Memif2Wireguard2Memif/README.md
+++ b/examples/use-cases/Memif2Wireguard2Memif/README.md
@@ -1,0 +1,139 @@
+# Test memif to wireguard to memif connection
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+NSC and NSE are using the `memif` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [basic](../../basic) or [memory](../../memory) setup.
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-memif
+- ../../../apps/nse-memif
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: memif://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-memif -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-memif -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+result=$(kubectl exec "${NSC}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.100 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+Ping from NSE to NSC:
+```bash
+result=$(kubectl exec "${NSE}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.101 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```


### PR DESCRIPTION
Logs from kind cluster:
```
--- PASS: TestRunBasicSuite (757.14s)
    --- PASS: TestRunBasicSuite/TestKernel2Kernel (93.10s)
    --- PASS: TestRunBasicSuite/TestKernel2Memif (42.42s)
    --- PASS: TestRunBasicSuite/TestKernel2Vxlan2Kernel (50.85s)
    --- PASS: TestRunBasicSuite/TestKernel2Vxlan2Memif (50.61s)
    --- PASS: TestRunBasicSuite/TestKernel2Wireguard2Kernel (55.96s)
    --- PASS: TestRunBasicSuite/TestKernel2Wireguard2Memif (50.45s)
    --- PASS: TestRunBasicSuite/TestMemif2Kernel (46.30s)
    --- PASS: TestRunBasicSuite/TestMemif2Memif (51.83s)
    --- PASS: TestRunBasicSuite/TestMemif2Vxlan2Kernel (44.83s)
    --- PASS: TestRunBasicSuite/TestMemif2Vxlan2Memif (50.26s)
    --- PASS: TestRunBasicSuite/TestMemif2Wireguard2Kernel (50.12s)
    --- PASS: TestRunBasicSuite/TestMemif2Wireguard2Memif (49.54s)
PASS
```

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>