### PR TITLE
fix: interdomain tests can fail on ci kind2kind

### DIFF
--- a/examples/interdomain/usecases/Kernel2Vxlan2Kernel/README.md
+++ b/examples/interdomain/usecases/Kernel2Vxlan2Kernel/README.md
@@ -76,10 +76,6 @@ Deploy NSE:
 kubectl apply -k .
 ```
 
-```bash
-kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-kernel -n ${NAMESPACE1}
-```
-
 Find NSE pod by labels:
 ```bash
 NSE=$(kubectl get pods -l app=nse-kernel -n ${NAMESPACE1} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
@@ -152,7 +148,7 @@ kubectl apply -k .
 
 Wait for applications ready:
 ```bash
-kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel -n ${NAMESPACE2}
+kubectl wait --for=condition=ready --timeout=5m pod -l app=nsc-kernel -n ${NAMESPACE2}
 ```
 
 


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Makes this https://github.com/networkservicemesh/integration-interdomain-k8s/pull/2 green