### PR TITLE
Add wireguard examples to separate suite

### DIFF
--- a/examples/use-cases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Kernel/README.md
@@ -1,0 +1,135 @@
+# Test kernel to wireguard to kernel connection
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+NSC and NSE are using the `kernel` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [wireguard](../../wireguard).
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-kernel
+- ../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: kernel://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-kernel -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+kubectl exec ${NSC} -n ${NAMESPACE} -- ping -c 4 172.16.1.100
+```
+
+Ping from NSE to NSC:
+```bash
+kubectl exec ${NSE} -n ${NAMESPACE} -- ping -c 4 172.16.1.101
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/use-cases/Kernel2Wireguard2Memif/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Memif/README.md
@@ -1,0 +1,138 @@
+# Test kernel to wireguard to memif
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+NSC is using the `kernel` mechanism to connect to its local forwarder.
+NSE is using the `memif` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [wireguard](../../wireguard).
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-kernel
+- ../../../apps/nse-memif
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: kernel://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-memif -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+kubectl exec ${NSC} -n ${NAMESPACE} -- ping -c 4 172.16.1.100
+```
+
+Ping from NSE to NSC:
+```bash
+result=$(kubectl exec "${NSE}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.101 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/use-cases/Memif2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Memif2Wireguard2Kernel/README.md
@@ -1,0 +1,139 @@
+# Test memif to wireguard to kernel connection
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+
+NSC is using the `memif` mechanism to connect to its local forwarder.
+NSE is using the `kernel` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [wireguard](../../wireguard).
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-memif
+- ../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: memif://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-memif -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-kernel -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-kernel -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+result=$(kubectl exec "${NSC}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.100 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+Ping from NSE to NSC:
+```bash
+kubectl exec ${NSE} -n ${NAMESPACE} -- ping -c 4 172.16.1.101
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/use-cases/Memif2Wireguard2Memif/README.md
+++ b/examples/use-cases/Memif2Wireguard2Memif/README.md
@@ -1,0 +1,139 @@
+# Test memif to wireguard to memif connection
+
+This example shows that NSC and NSE on the different nodes could find and work with each other.
+
+NSC and NSE are using the `memif` mechanism to connect to its local forwarder.
+Forwarders are using the `wireguard` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [wireguard](../../wireguard).
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Get nodes exclude control-plane:
+```bash
+NODES=($(kubectl get nodes -o go-template='{{range .items}}{{ if not .spec.taints  }}{{index .metadata.labels "kubernetes.io/hostname"}} {{end}}{{end}}'))
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-memif
+- ../../../apps/nse-memif
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: memif://icmp-responder/nsm-1
+
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[0]}
+EOF
+
+```
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-memif
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+            - name: NSE_PAYLOAD
+              value: IP
+      nodeSelector:
+        kubernetes.io/hostname: ${NODES[1]}
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsc-memif -n ${NAMESPACE}
+```
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-memif -n ${NAMESPACE}
+```
+
+Find NSC and NSE pods by labels:
+```bash
+NSC=$(kubectl get pods -l app=nsc-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+NSE=$(kubectl get pods -l app=nse-memif -n ${NAMESPACE} --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+result=$(kubectl exec "${NSC}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.100 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+Ping from NSE to NSC:
+```bash
+result=$(kubectl exec "${NSE}" -n "${NAMESPACE}" -- vppctl ping 172.16.1.101 repeat 4)
+echo ${result}
+! echo ${result} | grep -E -q "(100% packet loss)|(0 sent)|(no egress interface)"
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```

--- a/examples/wireguard/README.md
+++ b/examples/wireguard/README.md
@@ -1,0 +1,58 @@
+# Wireguard examples
+
+Contain basic setup for NSM that includes `nsmgr`, `forwarder-vpp`, `registry-k8s`. This setup can be used to check mechanisms combination or some kind of NSM [features](../features).
+
+## Requires
+
+- [spire](../spire)
+
+## Includes
+
+- [Kernel to Wireguard to Kernel Connection](../use-cases/Kernel2Wireguard2Kernel)
+- [Memif to Wireguard to Memif Connection](../use-cases/Memif2Wireguard2Memif)
+- [Kernel to Wireguard to Memif Connection](../use-cases/Kernel2Wireguard2Memif)
+- [Memif to Wireguard to Kernel Connection](../use-cases/Memif2Wireguard2Kernel)
+
+## Run
+
+1. Create ns for deployments:
+```bash
+kubectl create ns nsm-system
+```
+
+2. Register `nsm-system` namespace in spire:
+
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/nsm-system/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:nsm-system \
+-selector k8s:sa:default
+```
+
+3. Register `registry-k8s-sa` in spire:
+
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/nsm-system/sa/registry-k8s-sa \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:nsm-system \
+-selector k8s:sa:registry-k8s-sa
+```
+
+4. Apply NSM resources for wireguard tests:
+
+```bash
+kubectl apply -k .
+```
+
+## Cleanup
+
+To free resouces follow the next command:
+
+```bash
+kubectl delete mutatingwebhookconfiguration --all
+kubectl delete ns nsm-system
+```

--- a/examples/wireguard/kustomization.yaml
+++ b/examples/wireguard/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nsm-system
+
+bases:
+- ../../apps/nsmgr
+- ../../apps/forwarder-vpp
+- ../../apps/registry-k8s
+- ../../apps/admission-webhook-k8s


### PR DESCRIPTION
Logs from kind-cluster:
```
--- PASS: TestRunWireguardSuite (384.51s)
    --- PASS: TestRunWireguardSuite/TestKernel2Wireguard2Kernel (96.83s)
    --- PASS: TestRunWireguardSuite/TestKernel2Wireguard2Memif (35.95s)
    --- PASS: TestRunWireguardSuite/TestMemif2Wireguard2Kernel (93.45s)
    --- PASS: TestRunWireguardSuite/TestMemif2Wireguard2Memif (46.65s)
PASS
```

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>