### PR TITLE
add ovs forwarder deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ This repository provides kubernetes yaml deployments and markdown examples for N
         * [Admisson webhook Example](./examples/features/webhook)
         * [Topology aware scale from zero](./examples/features/scale-from-zero)
     * [SRIOV examples](./examples/sriov)
+    * [OVS examples](./examples/ovs)
     * [Memory examples](./examples/memory)
     * [Heal examples](./examples/heal)

--- a/apps/forwarder-host-ovs/forwarder.yaml
+++ b/apps/forwarder-host-ovs/forwarder.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: forwarder-ovs
+  labels:
+    app: forwarder-ovs
+spec:
+  selector:
+    matchLabels:
+      app: forwarder-ovs
+  template:
+    metadata:
+      labels:
+        app: forwarder-ovs
+    spec:
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - image: networkservicemeshci/cmd-forwarder-host-ovs:latest
+          imagePullPolicy: IfNotPresent
+          name: forwarder-ovs
+          securityContext:
+            privileged: true
+          env:
+            - name: NSM_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+            - name: NSM_SRIOV_CONFIG_FILE
+              value: /var/lib/networkservicemesh/sriov.config
+            - name: NSM_BRIDGE_NAME
+              value: br-nsm
+            - name: NSM_TUNNEL_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm
+              mountPath: /var/lib/networkservicemesh
+            - name: kubelet-socket
+              mountPath: /var/lib/kubelet
+            - name: cgroup
+              mountPath: /host/sys/fs/cgroup
+            - name: vfio
+              mountPath: /host/dev/vfio
+            - name: ovs-socket
+              mountPath: /var/run/openvswitch
+              readOnly: true
+          resources:
+            limits:
+              memory: 40Mi
+              cpu: 200m
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: Directory
+        - name: kubelet-socket
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio
+            type: DirectoryOrCreate
+        - name: ovs-socket
+          hostPath:
+             path: /var/run/openvswitch
+             type: DirectoryOrCreate

--- a/apps/forwarder-host-ovs/forwarder.yaml
+++ b/apps/forwarder-host-ovs/forwarder.yaml
@@ -17,7 +17,7 @@ spec:
       hostPID: true
       hostNetwork: true
       containers:
-        - image: networkservicemeshci/cmd-forwarder-host-ovs:latest
+        - image: ghcr.io/networkservicemesh/ci/cmd-forwarder-ovs-use-host-ovs:811ba56
           imagePullPolicy: IfNotPresent
           name: forwarder-ovs
           securityContext:
@@ -56,8 +56,8 @@ spec:
               readOnly: true
           resources:
             limits:
-              memory: 40Mi
-              cpu: 200m
+              memory: 1Gi
+              cpu: 2
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/apps/forwarder-host-ovs/kustomization.yaml
+++ b/apps/forwarder-host-ovs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- forwarder.yaml

--- a/apps/forwarder-ovs/forwarder.yaml
+++ b/apps/forwarder-ovs/forwarder.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: forwarder-ovs
+  labels:
+    app: forwarder-ovs
+spec:
+  selector:
+    matchLabels:
+      app: forwarder-ovs
+  template:
+    metadata:
+      labels:
+        app: forwarder-ovs
+    spec:
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - image: networkservicemeshci/cmd-forwarder-ovs:latest
+          imagePullPolicy: IfNotPresent
+          name: forwarder-ovs
+          securityContext:
+            privileged: true
+          env:
+            - name: NSM_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+            - name: NSM_SRIOV_CONFIG_FILE
+              value: /var/lib/networkservicemesh/sriov.config
+            - name: NSM_BRIDGE_NAME
+              value: br-nsm
+            - name: NSM_TUNNEL_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm
+              mountPath: /var/lib/networkservicemesh
+            - name: kubelet-socket
+              mountPath: /var/lib/kubelet
+            - name: cgroup
+              mountPath: /host/sys/fs/cgroup
+            - name: vfio
+              mountPath: /host/dev/vfio
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: 2
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: Directory
+        - name: kubelet-socket
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio
+            type: DirectoryOrCreate

--- a/apps/forwarder-ovs/forwarder.yaml
+++ b/apps/forwarder-ovs/forwarder.yaml
@@ -17,7 +17,7 @@ spec:
       hostPID: true
       hostNetwork: true
       containers:
-        - image: networkservicemeshci/cmd-forwarder-ovs:latest
+        - image: ghcr.io/networkservicemesh/ci/cmd-forwarder-ovs:811ba56
           imagePullPolicy: IfNotPresent
           name: forwarder-ovs
           securityContext:

--- a/apps/forwarder-ovs/kustomization.yaml
+++ b/apps/forwarder-ovs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- forwarder.yaml

--- a/examples/ovs/README.md
+++ b/examples/ovs/README.md
@@ -1,4 +1,4 @@
-# Basic examples
+# OVS examples
 
 Contain basic setup for NSM that includes `nsmgr`, `forwarder-ovs`, `registry-k8s`, `admission-webhook-k8s`. This setup can be used to check mechanisms combination or some kind of NSM [features](../features).
 

--- a/examples/ovs/README.md
+++ b/examples/ovs/README.md
@@ -1,0 +1,56 @@
+# Basic examples
+
+Contain basic setup for NSM that includes `nsmgr`, `forwarder-ovs`, `registry-k8s`, `admission-webhook-k8s`. This setup can be used to check mechanisms combination or some kind of NSM [features](../features).
+
+## Requires
+
+- [spire](../spire)
+
+## Includes
+
+- [Kernel to Kernel Connection](../use-cases/Kernel2Kernel)
+- [SmartVF to SmartVF Connection](../use-cases/SmartVF2SmartVF)
+
+## Run
+
+1. Create ns for deployments:
+```bash
+kubectl create ns nsm-system
+```
+
+2. Register `nsm-system` namespace in spire:
+
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/nsm-system/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:nsm-system \
+-selector k8s:sa:default
+```
+
+3. Register `registry-k8s-sa` in spire:
+
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/nsm-system/sa/registry-k8s-sa \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:nsm-system \
+-selector k8s:sa:registry-k8s-sa
+```
+
+4. Apply NSM resources for basic tests:
+
+```bash
+kubectl apply -k .
+```
+
+## Cleanup
+
+To free resouces follow the next command:
+
+```bash
+kubectl delete mutatingwebhookconfiguration --all
+kubectl delete ns nsm-system
+```

--- a/examples/ovs/kustomization.yaml
+++ b/examples/ovs/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nsm-system
+
+bases:
+- ../../apps/nsmgr
+- ../../apps/forwarder-ovs
+- ../../apps/registry-k8s
+- ../../apps/admission-webhook-k8s

--- a/examples/use-cases/SmartVF2SmartVF/README.md
+++ b/examples/use-cases/SmartVF2SmartVF/README.md
@@ -36,7 +36,6 @@ namespace: ${NAMESPACE}
 bases:
 - ../../../apps/nsc-kernel
 - ../../../apps/nse-kernel
-- ../../../apps/nsc-kernel-ponger
 
 
 patchesStrategicMerge:
@@ -81,9 +80,9 @@ spec:
       containers:
         - name: nse
           env:
-            - name: NSE_LABELS
+            - name: NSM_LABELS
               value: serviceDomain:worker.domain
-            - name: NSE_CIDR_PREFIX
+            - name: NSM_CIDR_PREFIX
               value: 172.16.1.100/31
           resources:
             limits:
@@ -102,9 +101,6 @@ kubectl -n ${NAMESPACE} wait --for=condition=ready --timeout=1m pod -l app=nsc-k
 ```
 ```bash
 kubectl -n ${NAMESPACE} wait --for=condition=ready --timeout=1m pod -l app=nse-kernel
-```
-```bash
-kubectl -n ${NAMESPACE} wait --for=condition=ready --timeout=1m pod -l app=ponger
 ```
 
 Get NSC pod:

--- a/examples/use-cases/SmartVF2SmartVF/README.md
+++ b/examples/use-cases/SmartVF2SmartVF/README.md
@@ -1,0 +1,125 @@
+# Test Smart VF connection
+
+This example shows that NSC and NSE can work with each other over the SmartVF dual mode (kernel or dpdk) connection.
+
+## Requires
+
+Make sure that you have completed steps from [ovs](../../ovs) setup.
+
+## Run
+
+Create test namespace:
+```bash
+NAMESPACE=($(kubectl create -f ../namespace.yaml)[0])
+NAMESPACE=${NAMESPACE:10}
+```
+
+Register namespace in `spire` server:
+```bash
+kubectl exec -n spire spire-server-0 -- \
+/opt/spire/bin/spire-server entry create \
+-spiffeID spiffe://example.org/ns/${NAMESPACE}/sa/default \
+-parentID spiffe://example.org/ns/spire/sa/spire-agent \
+-selector k8s:ns:${NAMESPACE} \
+-selector k8s:sa:default
+```
+
+Create customization file:
+```bash
+cat > kustomization.yaml <<EOF
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+bases:
+- ../../../apps/nsc-kernel
+- ../../../apps/nse-kernel
+- ../../../apps/nsc-kernel-ponger
+
+
+patchesStrategicMerge:
+- patch-nsc.yaml
+- patch-nse.yaml
+EOF
+```
+
+Create NSC patch:
+```bash
+cat > patch-nsc.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsc-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nsc
+          env:
+            - name: NSM_NETWORK_SERVICES
+              value: kernel://icmp-responder/nsm-1?sriovToken=worker.domain/100G
+          resources:
+            limits:
+              worker.domain/100G: 1
+EOF
+```
+
+Create NSE patch:
+```bash
+cat > patch-nse.yaml <<EOF
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSE_LABELS
+              value: serviceDomain:worker.domain
+            - name: NSE_CIDR_PREFIX
+              value: 172.16.1.100/31
+          resources:
+            limits:
+              worker.domain/100G: 1
+EOF
+```
+
+Deploy NSC and NSE:
+```bash
+kubectl apply -k .
+```
+
+Wait for applications ready:
+```bash
+kubectl -n ${NAMESPACE} wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel
+```
+```bash
+kubectl -n ${NAMESPACE} wait --for=condition=ready --timeout=1m pod -l app=nse-kernel
+```
+```bash
+kubectl -n ${NAMESPACE} wait --for=condition=ready --timeout=1m pod -l app=ponger
+```
+
+Get NSC pod:
+```bash
+NSC=$(kubectl -n ${NAMESPACE} get pods -l app=nsc-kernel --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+Ping from NSC to NSE:
+```bash
+kubectl -n ${NAMESPACE} exec ${NSC} -- ping -c 4 172.16.1.100
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ${NAMESPACE}
+```


### PR DESCRIPTION
adds ovs forwarder deployment examples, would help to test [cmd-forwarder-ovs](https://github.com/networkservicemesh/cmd-forwarder-ovs) for which the code development is on going.

Depends on cmd-forwarder-ovs [PR]( https://github.com/networkservicemesh/cmd-forwarder-ovs/pull/7).

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>