### PR TITLE
[qfix] Change missed NSE_ prefix to NSM_

### DIFF
--- a/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
@@ -81,7 +81,7 @@ spec:
       containers:
         - name: nse
           env:
-            - name: NSE_CIDR_PREFIX
+            - name: NSM_CIDR_PREFIX
               value: 172.16.1.100/31
       nodeSelector:
         kubernetes.io/hostname: ${NODES[1]}


### PR DESCRIPTION
## Description
Missed in https://github.com/networkservicemesh/deployments-k8s/pull/2121.

## Issue
Fixes failing packet tests - https://github.com/networkservicemesh/integration-k8s-packet/pull/100/checks?check_run_id=3110629492.