### PR TITLE
TestWebhook: change the order of waiting for applications

### DIFF
--- a/examples/features/webhook/README.md
+++ b/examples/features/webhook/README.md
@@ -122,10 +122,10 @@ kubectl apply -k .
 
 8. Wait for applications ready:
 ```bash
-kubectl wait --for=condition=ready --timeout=1m pod postgres-cl -n ${NAMESPACE}
+kubectl wait --for=condition=ready --timeout=5m pod -l app=nse-kernel -n ${NAMESPACE}
 ```
 ```bash
-kubectl wait --for=condition=ready --timeout=5m pod -l app=nse-kernel -n ${NAMESPACE}
+kubectl wait --for=condition=ready --timeout=1m pod postgres-cl -n ${NAMESPACE}
 ```
 
 9. Find NSC and NSE pods by labels:


### PR DESCRIPTION
When the client application starts, the `init-container` runs first. It sends request to `nse` that is not ready yet - it is pulling `postgres` image, that is not very lightweight.
In this case, we first need to wait for the ready status from `nse`.

https://github.com/networkservicemesh/deployments-k8s/issues/2376

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>