### PR TITLE
[qfix] Increase memory limit for VPP applications

### DIFF
--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -48,7 +48,7 @@ spec:
             requests:
               cpu: 150m
             limits:
-              memory: 400Mi
+              memory: 500Mi
               cpu: 500m
           readinessProbe:
             exec:


### PR DESCRIPTION
## Description
Upgraded VPP consumes more memory, so `400Mi` limit is not enough.

## Issue
https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/332