### PR TITLE
fix: spire interdomain example is incorrect with new kubernetes clients

### DIFF
--- a/examples/interdomain/spire/cluster1/kustomization.yaml
+++ b/examples/interdomain/spire/cluster1/kustomization.yaml
@@ -7,12 +7,15 @@ namespace: spire
 configMapGenerator:
 - name: spire-server
   behavior: merge
+  namespace: spire
   files:
   - server.conf
 - name: spire-agent
   behavior: merge
+  namespace: spire
   files:
   - agent.conf
+
 
 bases:
 - ../../../spire

--- a/examples/interdomain/spire/cluster2/kustomization.yaml
+++ b/examples/interdomain/spire/cluster2/kustomization.yaml
@@ -7,12 +7,15 @@ namespace: spire
 configMapGenerator:
 - name: spire-server
   behavior: merge
+  namespace: spire
   files:
   - server.conf
 - name: spire-agent
   behavior: merge
+  namespace: spire
   files:
   - agent.conf
+
 
 bases:
 - ../../../spire

--- a/examples/interdomain/spire/cluster3/kustomization.yaml
+++ b/examples/interdomain/spire/cluster3/kustomization.yaml
@@ -7,10 +7,12 @@ namespace: spire
 configMapGenerator:
 - name: spire-server
   behavior: merge
+  namespace: spire
   files:
   - server.conf
 - name: spire-agent
   behavior: merge
+  namespace: spire
   files:
   - agent.conf
 


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


## Motivation

Makes example working correctly with kubectl 1.19+

Related to https://github.com/kubernetes-sigs/kustomize/pull/1460

