### PR TITLE
[qfix] Add missed mounts to VPP Forwarder deployment

### DIFF
--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -44,6 +44,12 @@ spec:
               readOnly: true
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
+            - name: kubelet-socket
+              mountPath: /var/lib/kubelet
+            - name: cgroup
+              mountPath: /host/sys/fs/cgroup
+            - name: vfio
+              mountPath: /host/dev/vfio
           resources:
             requests:
               cpu: 150m
@@ -64,4 +70,16 @@ spec:
         - name: nsm-socket
           hostPath:
             path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate
+        - name: kubelet-socket
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio
             type: DirectoryOrCreate


### PR DESCRIPTION
## Description
Adds missed mounts to VPP Forwarder deployment.

## Related to
https://github.com/networkservicemesh/integration-k8s-packet/pull/132