### PR TITLE
bump: Update NSM CRD api version to v1

### DIFF
--- a/apps/registry-k8s/crd-ns.yaml
+++ b/apps/registry-k8s/crd-ns.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkservices.networkservicemesh.io

--- a/apps/registry-k8s/crd-nse.yaml
+++ b/apps/registry-k8s/crd-nse.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkserviceendpoints.networkservicemesh.io


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

`apiextensions.k8s.io/v1beta1` is dropped by v1.22+