### PR TITLE
[deployments-k8s#3053] Increase CPU limits for NSM applications

### DIFF
--- a/apps/nsc-kernel/nsc.yaml
+++ b/apps/nsc-kernel/nsc.yaml
@@ -35,7 +35,7 @@ spec:
           resources:
             limits:
               memory: 40Mi
-              cpu: 100m
+              cpu: 200m
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/apps/nsc-vfio/nsc.yaml
+++ b/apps/nsc-vfio/nsc.yaml
@@ -49,7 +49,7 @@ spec:
           resources:
             limits:
               memory: 40Mi
-              cpu: 100m
+              cpu: 200m
               # We expect SR-IOV forwarders on the nodes to be configured:
               # master - provides PCI functions targeted to the worker.domain/10G
               # worker - provides PCI functions targeted to the master.domain/10G

--- a/apps/nse-kernel/nse.yaml
+++ b/apps/nse-kernel/nse.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               memory: 40Mi
-              cpu: 100m
+              cpu: 200m
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -51,7 +51,7 @@ spec:
           resources:
             limits:
               memory: 100Mi
-              cpu: 200m
+              cpu: 400m
           readinessProbe:
             exec:
               command: ["/bin/grpc-health-probe", "-spiffe", "-addr=:5001"]

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -49,6 +49,8 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
           resources:
+            requests:
+              cpu: 200m
             limits:
               memory: 100Mi
               cpu: 400m

--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -39,7 +39,7 @@ spec:
           resources:
             limits:
               memory: 40Mi
-              cpu: 100m
+              cpu: 200m
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/apps/registry-memory/registry-memory.yaml
+++ b/apps/registry-memory/registry-memory.yaml
@@ -34,7 +34,7 @@ spec:
           resources:
             limits:
               memory: 40Mi
-              cpu: 100m
+              cpu: 200m
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/examples/features/nse-composition/README.md
+++ b/examples/features/nse-composition/README.md
@@ -71,8 +71,6 @@ spec:
           env:
             - name: NSM_NETWORK_SERVICES
               value: kernel://nse-composition/nsm-1
-            - name: NSM_REQUEST_TIMEOUT
-              value: 75s
       nodeSelector:
         kubernetes.io/hostname: ${NODE}
 EOF


### PR DESCRIPTION
## Description
Increases CPU limits for NSM applications. Initial Request for NSE Composition example starts taking less than `10s`.

## Issue
https://github.com/networkservicemesh/deployments-k8s/issues/3053

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
