### PR TITLE
[qfix] Remove spire-data volume

### DIFF
--- a/examples/spire/server-statefulset.yaml
+++ b/examples/spire/server-statefulset.yaml
@@ -32,9 +32,6 @@ spec:
             - name: spire-config
               mountPath: /run/spire/config
               readOnly: true
-            - name: spire-data
-              mountPath: /run/spire/data
-              readOnly: false
             - name: spire-registration-socket
               mountPath: /tmp
               readOnly: false
@@ -87,13 +84,3 @@ spec:
             name: k8s-workload-registrar
         - name: spire-registration-socket
           emptyDir: {}
-  volumeClaimTemplates:
-    - metadata:
-        name: spire-data
-        namespace: spire
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi


### PR DESCRIPTION
It already was removed in 585a9205131e1bdcd25fdd023d94f858a43293ee and was accidentally added back in 1677c61004caff80ed40a3eb7e0c1d3e5568a219.

Needed to fix https://github.com/networkservicemesh/integration-k8s-packet/pull/141.