### PR TITLE
[integration-k8s-kind#325] Fix DNS test to use dnsutils

### DIFF
--- a/examples/features/dns/.gitignore
+++ b/examples/features/dns/.gitignore
@@ -1,1 +1,1 @@
-alpine.yaml
+dnsutils.yaml

--- a/external-images.yaml
+++ b/external-images.yaml
@@ -12,3 +12,4 @@ images:
   - quay.io/metallb/controller:v0.10.2
   - docker.io/library/alpine:latest
   - docker.io/frolvlad/alpine-bash:latest
+  - gcr.io/kubernetes-e2e-test-images/dnsutils:1.3


### PR DESCRIPTION
## Description

1. Starts using `dnsutils` instead of `alpine` in DNS test.
2. Checks for `kubernetes.default` hostname instead of `google.com`.

## Issue link

networkservicemesh/integration-k8s-kind#325

## How Has This Been Tested?

<!--- Provide information on how these changes are testing -->

- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes

<!--- What types of changes does your code introduce -->

- [x] ~Bug~ Test fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI