### PR TITLE
[qfix] Fix DNS test

### DIFF
--- a/examples/features/dns/README.md
+++ b/examples/features/dns/README.md
@@ -149,7 +149,7 @@ NSE=$(kubectl get pods -l app=nse-kernel -n ${NAMESPACE} --template '{{range .it
 
 9. Ping from dnsutils to NSE by domain name:
 ```bash
-kubectl exec ${NSC} -c dnsutils -n ${NAMESPACE} -- nslookup -norec my.coredns.service
+kubectl exec ${NSC} -c dnsutils -n ${NAMESPACE} -- nslookup -norec -nodef my.coredns.service
 ```
 ```bash
 kubectl exec ${NSC} -c dnsutils -n ${NAMESPACE} -- ping -c 4 my.coredns.service


### PR DESCRIPTION
## Description

Returns back `-nodef` for the `my.coredns.service` nslookup.

## How Has This Been Tested?

<!--- Provide information on how these changes are testing -->

- [ ] Added unit testing to cover
- [x] Tested manually on kind
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes

<!--- What types of changes does your code introduce -->

- [x] ~Bug~ Test fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI