### PR TITLE
Revert "Switched to metadata.labels"

### DIFF
--- a/examples/features/nse-composition/README.md
+++ b/examples/features/nse-composition/README.md
@@ -77,9 +77,6 @@ metadata:
   name: nse-kernel
 spec:
   template:
-    metadata:
-      labels:
-        app: gateway
     spec:
       containers:
         - name: nse
@@ -91,9 +88,7 @@ spec:
             - name: NSM_REGISTER_SERVICE
               value: "false"
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: "app:gateway"
         - name: nginx
           image: networkservicemesh/nginx
           imagePullPolicy: IfNotPresent

--- a/examples/features/nse-composition/nse-firewall/patch-nse-firewall-vpp.yaml
+++ b/examples/features/nse-composition/nse-firewall/patch-nse-firewall-vpp.yaml
@@ -5,9 +5,6 @@ metadata:
   name: nse-firewall-vpp
 spec:
   template:
-    metadata:
-      labels:
-        app: firewall
     spec:
       containers:
         - name: nse
@@ -15,6 +12,4 @@ spec:
             - name: NSM_SERVICE_NAME
               value: "nse-composition"
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: app:firewall

--- a/examples/features/nse-composition/passthrough-1.yaml
+++ b/examples/features/nse-composition/passthrough-1.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: passthrough-1
+      app: nse-firewall-vpp
   template:
     metadata:
       labels:
-        app: passthrough-1
+        app: nse-firewall-vpp
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
@@ -23,9 +23,7 @@ spec:
             - name: NSM_SERVICE_NAME
               value: nse-composition
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: app:passthrough-1
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_NAME

--- a/examples/features/nse-composition/passthrough-2.yaml
+++ b/examples/features/nse-composition/passthrough-2.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: passthrough-2
+      app: nse-firewall-vpp
   template:
     metadata:
       labels:
-        app: passthrough-2
+        app: nse-firewall-vpp
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
@@ -23,9 +23,7 @@ spec:
             - name: NSM_SERVICE_NAME
               value: nse-composition
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: app:passthrough-2
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_NAME

--- a/examples/features/nse-composition/passthrough-3.yaml
+++ b/examples/features/nse-composition/passthrough-3.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: passthrough-3
+      app: nse-firewall-vpp
   template:
     metadata:
       labels:
-        app: passthrough-3
+        app: nse-firewall-vpp
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
@@ -23,9 +23,7 @@ spec:
             - name: NSM_SERVICE_NAME
               value: nse-composition
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: app:passthrough-3
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_NAME

--- a/examples/features/scale-from-zero/pod-template.yaml
+++ b/examples/features/scale-from-zero/pod-template.yaml
@@ -26,9 +26,7 @@ spec:
         - name: NSM_SERVICE_NAMES
           value: autoscale-icmp-responder
         - name: NSM_LABELS
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels
+          value: app:nse-icmp-responder
         - name: NSM_IDLE_TIMEOUT
           value: 15s
       volumeMounts:

--- a/examples/use-cases/SmartVF2SmartVF/README.md
+++ b/examples/use-cases/SmartVF2SmartVF/README.md
@@ -67,16 +67,11 @@ metadata:
 spec:
   template:
     spec:
-      metadata:
-        labels:
-          serviceDomain:worker.domain
       containers:
         - name: nse
           env:
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: serviceDomain:worker.domain
             - name: NSM_CIDR_PREFIX
               value: 172.16.1.100/31
           resources:

--- a/examples/use-cases/SriovKernel2Noop/README.md
+++ b/examples/use-cases/SriovKernel2Noop/README.md
@@ -68,16 +68,11 @@ metadata:
 spec:
   template:
     spec:
-      metadata:
-        labels:
-          serviceDomain:worker.domain
       containers:
         - name: nse
           env:
             - name: NSM_LABELS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels
+              value: serviceDomain:worker.domain
             - name: NSM_CIDR_PREFIX
               value: 172.16.1.100/31
           resources:


### PR DESCRIPTION
Reverts networkservicemesh/deployments-k8s#3685

## Description
`metadata.labels` not working as supposed
Because of incorrect testing, PR adding labels was merged
Since our main priority now is stability prior to release we reverting it now and return to it later

## Issue 
https://github.com/networkservicemesh/deployments-k8s/issues/3437