### PR TITLE
qfix: Increase limits for cmd-exclude-prefixes-k8s

### DIFF
--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -77,8 +77,8 @@ spec:
               mountPath: /var/lib/networkservicemesh/config/
           resources:
             limits:
-              memory: 10Mi
-              cpu: 50m
+              memory: 40Mi
+              cpu: 75m
       volumes:
         - name: spire-agent-socket
           hostPath:


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

memory: 10Mi is not enough for AKS clusters.

By my local investigation, 25Mi is enough for https://github.com/networkservicemesh/deployments-k8s/blob/main/apps/nsmgr-proxy/nsmgr-proxy.yaml#L74

So  cmd-exclude-prefixes-k8s is a more complex application and it should require more resources.

Potentially closes https://github.com/networkservicemesh/integration-k8s-kind/issues/463

