### PR TITLE
qfix: Format of examples/features/select-forwarder/service.yaml is incorrect 

### DIFF
--- a/examples/features/select-forwarder/service.yaml
+++ b/examples/features/select-forwarder/service.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   payload: ETHERNET
   matches:
-  - routes:
-    - destination_selector: {}
-    metadata:
-      labels:
-        my_forwarder_capability: true
+    - routes:
+        - destination_selector: {}
+      metadata:
+        labels:
+          my_forwarder_capability: true


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

Closes https://github.com/networkservicemesh/integration-k8s-kind/pull/506