### PR TITLE
qfix: links for interdomain and floating interdomain examples are incorrect for root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ This repository provides kubernetes yaml deployments and markdown examples for N
 * [Applications](./apps)
 * Examples
     * [Basic examples](./examples/basic) 
-    * [Interdomain examples](./examples/interdomain/basic)
-    * [Floating interdomain examples](./examples/floating)
+    * [Interdomain and floating interdomain examples](./examples/interdomain)
     * [Features examples](./examples/features)
         * [OPA example](./examples/features/opa)
         * [IPv6 examples](./examples/features/ipv6)


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>