### PR TITLE
qfix: add getting logs from cmd-nsc container for select-forwarder example

### DIFF
--- a/examples/features/select-forwarder/README.md
+++ b/examples/features/select-forwarder/README.md
@@ -58,7 +58,7 @@ kubectl exec ${NSE} -n select-forwarder -- ping -c 4 169.254.0.1
 
 Verify that NSMgr selected the correct forwarder:
 ```bash
-kubectl logs ${NSC} -n select-forwarder | grep "my-forwarder-vpp"
+kubectl logs ${NSC} -c cmd-nsc -n select-forwarder | grep "my-forwarder-vpp"
 ```
 
 ## Cleanup


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Fixes
```
time=2021-12-12T20:19:36Z level=info msg=error: a container name must be specified for pod alpine, choose one of: [alpine cmd-nsc coredns] or one of the init containers: [cmd-nsc-init] TestRunFeatureSuite/TestSelect_forwarder=stderr
```