### PR TITLE
qfix: remove extra quotes from Floating kernel2wireguard2kernel example

### DIFF
--- a/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
+++ b/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
@@ -63,7 +63,7 @@ spec:
         - name: nse
           env:
           - name: NSM_NAME
-            value: "icmp-server@my.cluster3"
+            value: icmp-server@my.cluster3
           - name: NSM_CIDR_PREFIX
             value: 172.16.1.2/31
           - name: NSM_SERVICE_NAMES


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Fixes problem on CI:
```
time=2021-12-12T23:29:44Z level=info msg=The Deployment "nse-kernel" is invalid: spec.template.spec.containers[0].env[0].valueFrom: Invalid value: "": may not be specified when `value` is not empty TestInterdomainBasicSuite/TestFloatingKernel2Wireguard2Kernel=stderr
time=2021-12-12T23:29:44Z level=info msg=1 TestInterdomainBasicSuite/TestFloatingKernel2Wireguard2Kernel=exitCode
```