### PR TITLE
qfix: use direct nse with correct NSM_NAME to avoid problems with kustomize merge

### DIFF
--- a/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
+++ b/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
@@ -40,36 +40,9 @@ kind: Kustomization
 
 namespace: ${NAMESPACE1}
 
-bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=5c91e94418078c19145f1d3354761176e8e3b716
+resources:
+- nse.yaml
 
-patchesStrategicMerge:
-- patch-nse.yaml
-EOF
-```
-
-Create NSE patch:
-```bash
-cat > patch-nse.yaml <<EOF
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nse-kernel
-spec:
-  template:
-    spec:
-      containers:
-        - name: nse
-          env:
-          - name: NSM_NAME
-            value: icmp-server@my.cluster3
-          - name: NSM_CIDR_PREFIX
-            value: 172.16.1.2/31
-          - name: NSM_SERVICE_NAMES
-            value: my-networkservice-ip@my.cluster3
-          - name: NSM_PAYLOAD
-            value: IP
 EOF
 ```
 

--- a/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/nse.yaml
+++ b/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/nse.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+  labels:
+    app: nse-kernel
+spec:
+  selector:
+    matchLabels:
+      app: nse-kernel
+  template:
+    metadata:
+      labels:
+        app: nse-kernel
+        "spiffe.io/spiffe-id": "true"
+    spec:
+      containers:
+        - name: nse
+          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:57c46e2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSM_NAME
+              value: icmp-server@my.cluster3
+            - name: NSM_LOG_LEVEL
+              value: TRACE
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 40Mi
+            limits:
+              memory: 80Mi
+              cpu: 200m
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Description

The current kustomization version in k8s cannot correct override envs. 

For example:

merge of

```
envs:
     name: a
     value: b
```

and
```
envs:
     name: a
     valueFrom
       ....myField.b
```

is not supported in the version of kustomization that using in kubectl

## Motivation

Closes https://github.com/networkservicemesh/deployments-k8s/pull/4056


