### PR TITLE
qfix: Spire external images are outdated

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -4,8 +4,8 @@
 images:
   - docker.io/library/postgres:latest
   - docker.io/coredns/coredns:1.8.3
-  - gcr.io/spiffe-io/spire-agent:1.0.2
-  - gcr.io/spiffe-io/spire-server:1.0.2
+  - gcr.io/spiffe-io/spire-agent:1.1.0
+  - gcr.io/spiffe-io/spire-server:1.1.0
   - quay.io/metallb/speaker:v0.10.2
   - gcr.io/spiffe-io/wait-for-it:latest
   - gcr.io/spiffe-io/k8s-workload-registrar:1.0.2


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

CI can fail due to long image pulling => prefersh is using outdated spire.

Real case: https://github.com/networkservicemesh/integration-k8s-kind/runs/4517530239?check_suite_focus=true

```
time=2021-12-14T09:15:13Z level=error msg=command didn't succeed until timeout cmd=kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent
    suite.go:130: 
        	Error Trace:	suite.go:130
        	            				suite.gen.go:29
        	            				suite.gen.go:23
        	            				suite.gen.go:23
        	            				suite.go:118
        	            				entry_point_test.go:35
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 1
```