### PR TITLE
Fix remote vlan example

### DIFF
--- a/apps/nse-remote-vlan/nse-remote-vlan.yaml
+++ b/apps/nse-remote-vlan/nse-remote-vlan.yaml
@@ -34,6 +34,8 @@ spec:
               value: "True"
             - name: NSM_LISTEN_ON
               value: "tcp://:5003"
+            - name: NSM_LOG_LEVEL
+              value: TRACE
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/examples/remotevlan/README.md
+++ b/examples/remotevlan/README.md
@@ -63,6 +63,8 @@ spec:
             value: "172.10.0.0/24"
           - name: NSM_IPV6_PREFIX
             value: "100:200::/64"
+          - name: NSM_MAX_TOKEN_LIFETIME
+            value: "60s"
 EOF
 ```
 

--- a/examples/use-cases/Kernel2RVlanBreakout/README.md
+++ b/examples/use-cases/Kernel2RVlanBreakout/README.md
@@ -112,7 +112,7 @@ Start iperf client on tester:
     do
       IP_ADDRESS=$(kubectl exec ${nsc} -c cmd-nsc -n ${NAMESPACE} -- ip -4 addr show nsm-1 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
       kubectl exec ${nsc} -c iperf-server -n ${NAMESPACE} -- iperf3 -sD -B ${IP_ADDRESS} -1
-      docker exec rvm-tester iperf3 -i0 -t 125 -c ${IP_ADDRESS}
+      docker exec rvm-tester iperf3 -i0 -t 25 -c ${IP_ADDRESS}
       if test $? -ne 0
       then
         status=1


### PR DESCRIPTION
Decrease MAX_TOKEN_LIFETIME in NSE to shorten the test run.
Add TRACE level logging to nse_remote_vlan
Signed-off-by: Laszlo Kiraly <laszlo.kiraly@est.tech>