### PR TITLE
qfix: add missed kustomization.yaml for vl3 example

### DIFF
--- a/examples/features/vl3/.gitignore
+++ b/examples/features/vl3/.gitignore
@@ -1,0 +1,1 @@
+!**/kustomization.yaml

--- a/examples/features/vl3/kustomization.yaml
+++ b/examples/features/vl3/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-vl3
+
+bases:
+- ../../../apps/nsc-kernel
+- ../../../apps/nse-vl3-vpp
+- ../../../apps/vl3-ipam
+
+patchesStrategicMerge:
+- nsc-patch.yaml
+- nse-patch.yaml


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

 kustomization.yaml  was missed in examples/features/vl3 due to .gitignore file in [examples/features/.gitignore.](https://github.com/networkservicemesh/deployments-k8s/blob/main/examples/features/.gitignore)
 
 