### PR TITLE
Decrease the scope of rvlanSuite to vpp forwarder only

### DIFF
--- a/examples/remotevlan/README.md
+++ b/examples/remotevlan/README.md
@@ -8,7 +8,6 @@ This setup can be used to check remote vlan mechanism with both OVS and VPP forw
 
 ## Includes
 
-- [Remote VLAN mechanism using forwarder-ovs](./rvlanovs)
 - [Remote VLAN mechanism using forwarder-vpp](./rvlanvpp)
 
 ## Run


### PR DESCRIPTION
Skip the ovs forwarder tests temporary 
Signed-off-by: Laszlo Kiraly <laszlo.kiraly@est.tech>