### PR TITLE
Change vfio pingpong image

### DIFF
--- a/apps/nsc-vfio/nsc.yaml
+++ b/apps/nsc-vfio/nsc.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       containers:
         - name: pinger
-          # https://github.com/Bolodya1997/docker-dpdk
-          image: rrandom312/dpdk-pingpong:latest
+          # https://github.com/glazychev-art/docker-dpdk
+          image: artgl/dpdk-pingpong:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "-c", "sleep 60m"]
           volumeMounts:

--- a/apps/nse-vfio/nse.yaml
+++ b/apps/nse-vfio/nse.yaml
@@ -18,8 +18,8 @@ spec:
       hostNetwork: true
       containers:
         - name: ponger
-          # https://github.com/Bolodya1997/docker-dpdk
-          image: rrandom312/dpdk-pingpong:latest
+          # https://github.com/glazychev-art/docker-dpdk
+          image: artgl/dpdk-pingpong:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "/root/scripts/pong.sh", "eno4", "31"]
           securityContext:


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/integration-k8s-packet/issues/261

The potential problem is here -
https://github.com/Bolodya1997/dpdk-pingpong/blob/d1e8000b72fc4d3170f8726b375836b66f09a270/main.c#L106

If `nb_pkts == port_statistics.dropped` we get divide by zero problem
And in the logs we see that the program is stuck on this line:
```
...
====== ping-pong statistics =====
tx 500 ping packets
rx 0 pong packets
dropped 500 packets TestMultiForwarder/TestKernel2Kernel_Vfio2Noop=stderr
```

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>