### PR TITLE
Fix streams for vfio tests

### DIFF
--- a/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
@@ -123,20 +123,20 @@ function dpdk_ping() {
   ' 2>"${err_file}")"
 
   if [[ "$?" != 0 ]]; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 
   if ! pong_packets="$(echo "${out}" | grep "rx .* pong packets" | sed -E 's/rx ([0-9]*) pong packets/\1/g')"; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 
   if [[ "${pong_packets}" == 0 ]]; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 

--- a/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
@@ -123,20 +123,20 @@ function dpdk_ping() {
   ' 2>"${err_file}")"
 
   if [[ "$?" != 0 ]]; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 
   if ! pong_packets="$(echo "${out}" | grep "rx .* pong packets" | sed -E 's/rx ([0-9]*) pong packets/\1/g')"; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 
   if [[ "${pong_packets}" == 0 ]]; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 

--- a/examples/use-cases/Vfio2Noop/README.md
+++ b/examples/use-cases/Vfio2Noop/README.md
@@ -64,20 +64,20 @@ function dpdk_ping() {
   ' 2>"${err_file}")"
 
   if [[ "$?" != 0 ]]; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 
   if ! pong_packets="$(echo "${out}" | grep "rx .* pong packets" | sed -E 's/rx ([0-9]*) pong packets/\1/g')"; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 
   if [[ "${pong_packets}" == 0 ]]; then
+    echo "${out}"
     cat "${err_file}" 1>&2
-    echo "${out}" 1>&2
     return 1
   fi
 


### PR DESCRIPTION
### Motivation

Vfio tests redirects streams in tests - `stdout` stream is never used.
Our bash utility uses channels to receive messages. Since we have nothing there, it just freezes on `stdout` receiving.
https://github.com/networkservicemesh/gotestmd/blob/main/pkg/bash/bash.go#L179

Issue: https://github.com/networkservicemesh/integration-k8s-packet/issues/261


Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>