### PR TITLE
fix: forwarder-vpp cpu may not be enough

### DIFF
--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -60,7 +60,7 @@ spec:
               cpu: 150m
             limits:
               memory: 500Mi
-              cpu: 500m
+              cpu: 525m
           readinessProbe:
             exec:
               command: ["/bin/grpc-health-probe", "-spiffe", "-addr=unix:///listen.on.sock"]


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

Faced on gke cluster
```
kubelet  Liveness probe failed: failed to initialize tls credentials with spiffe. error=context deadline exceeded
```


This PR should fix the problem.