### PR TITLE
Remove TunnelIp env from the k8s_docker configuration

### DIFF
--- a/examples/k8s_monolith/docker/README.md
+++ b/examples/k8s_monolith/docker/README.md
@@ -4,8 +4,7 @@ This example shows how to start docker container using `docker compose`
 
 ## Run
 
-Create kustomization file. Use static IP for the kind cluster. Make sure that user defined `kind` network with 172.18.0.0/16 is used.
-For example: `docker network create kind --subnet=172.18.0.0/16`
+Create kustomization file for the kind cluster:
 ```bash
 cat > docker-compose.override.yaml <<EOF
 ---
@@ -16,10 +15,7 @@ networks:
 services:
   nse-simple-vl3-docker:
     networks:
-      kind:
-        ipv4_address: 172.18.0.50
-    environment:
-      NSM_TUNNEL_IP: 172.18.0.50
+      - kind
 EOF
 ```
 


### PR DESCRIPTION
### Description
We don't need to use static IP for the kind-cluster - if we don't set `NSM_TUNNEL_IP`, it will be resolved automatically by the default route:
https://github.com/networkservicemesh/cmd-nse-simple-vl3-docker/blob/main/vppinit/vppinit.go#L51-L53

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>