### PR TITLE
[qfix] Rename cmd-nse-simple-vl3-docker to nse-simple-vl3-docker

### DIFF
--- a/apps/nse-simple-vl3-docker/docker-compose.yaml
+++ b/apps/nse-simple-vl3-docker/docker-compose.yaml
@@ -1,9 +1,9 @@
 ---
 services:
   nse-simple-vl3-docker:
-    image: ghcr.io/networkservicemesh/ci/cmd-nse-simple-vl3-docker:3687416
+    image: ghcr.io/networkservicemesh/ci/cmd-nse-simple-vl3-docker:3ee9c60
     privileged: true
-    container_name: cmd-nse-simple-vl3-docker
+    container_name: nse-simple-vl3-docker
     restart: always
     environment:
       NSM_NAME: docker-vl3-server@k8s.nsm

--- a/examples/k8s_monolith/dns/README.md
+++ b/examples/k8s_monolith/dns/README.md
@@ -28,7 +28,7 @@ echo Selected externalIP: $ipk8s
 
 2. Get an externalIP of the docker container:
 ```bash
-ipdock=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cmd-nse-simple-vl3-docker)
+ipdock=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nse-simple-vl3-docker)
 echo Selected dockerIP: $ipdock
 [[ ! -z $ipdock ]]
 ```
@@ -87,13 +87,13 @@ kubectl rollout restart -n kube-system deployment/coredns
 
 Save the initial `resolv.conf` in a separate file:
 ```bash
-docker exec -d -i cmd-nse-simple-vl3-docker cp /etc/resolv.conf /etc/resolv_init.conf
+docker exec -d -i nse-simple-vl3-docker cp /etc/resolv.conf /etc/resolv_init.conf
 ```
 
 Add an entry to `resolv.conf` with a coredns address.
 Use a custom address to reduce the chance of it being used (default is 127.0.0.1)
 ```bash
-docker exec -d -i cmd-nse-simple-vl3-docker sh -c "echo 'nameserver 127.0.1.1' > /etc/resolv.conf"
+docker exec -d -i nse-simple-vl3-docker sh -c "echo 'nameserver 127.0.1.1' > /etc/resolv.conf"
 ```
 
 Create coredns config file:
@@ -137,17 +137,17 @@ EOF
 ```
 
 ```bash
-docker cp coredns-config cmd-nse-simple-vl3-docker:/
+docker cp coredns-config nse-simple-vl3-docker:/
 ```
 
 ```bash
-docker cp dnsentries.db cmd-nse-simple-vl3-docker:/
+docker cp dnsentries.db nse-simple-vl3-docker:/
 ```
 
 Run coredns with this config:
 
 ```bash
-docker exec -d cmd-nse-simple-vl3-docker coredns -conf coredns-config
+docker exec -d nse-simple-vl3-docker coredns -conf coredns-config
 ```
 
 ## Cleanup

--- a/examples/k8s_monolith/spire/README.md
+++ b/examples/k8s_monolith/spire/README.md
@@ -27,9 +27,9 @@ To enable the SPIRE Servers to fetch the trust bundles from each other they need
 Get and store bundles of the k8s cluster and the docker container:
 ```bash
 bundlek8s=$(kubectl exec spire-server-0 -n spire -- bin/spire-server bundle show -format spiffe)
-bundledock=$(docker exec cmd-nse-simple-vl3-docker bin/spire-server bundle show -format spiffe)
+bundledock=$(docker exec nse-simple-vl3-docker bin/spire-server bundle show -format spiffe)
 echo $bundledock | kubectl exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://docker.nsm/cmd-nse-simple-vl3-docker"
-echo $bundlek8s | docker exec -i cmd-nse-simple-vl3-docker bin/spire-server bundle set -format spiffe -id "spiffe://k8s.nsm"
+echo $bundlek8s | docker exec -i nse-simple-vl3-docker bin/spire-server bundle set -format spiffe -id "spiffe://k8s.nsm"
 ```
 
 ## Cleanup

--- a/examples/k8s_monolith/usecases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/k8s_monolith/usecases/Kernel2Wireguard2Kernel/README.md
@@ -97,7 +97,7 @@ for nsc in $nscs
 do
     ipAddr=$(kubectl exec -n ${NAMESPACE} $nsc -- ifconfig nsm-1)
     ipAddr=$(echo $ipAddr | grep -Eo 'inet addr:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'| cut -c 11-)
-    docker exec cmd-nse-simple-vl3-docker ping -c4 $ipAddr
+    docker exec nse-simple-vl3-docker ping -c4 $ipAddr
 done
 ```
 


### PR DESCRIPTION
We need this because updating the image tag is incorrect.

Closes: https://github.com/networkservicemesh/deployments-k8s/pull/6102

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>