### PR TITLE
scale_form_zero: limit the length of the name

### DIFF
--- a/examples/features/scale-from-zero/pod-template.yaml
+++ b/examples/features/scale-from-zero/pod-template.yaml
@@ -2,7 +2,8 @@
 apiVersion: apps/v1
 kind: Pod
 metadata:
-  name: nse-icmp-responder-{{ index .Labels "nodeName" }}
+  # Limit the length of the name. Spire doesn't work with the length > 63
+  name: nse-icmp-responder-{{ printf "%.39s"  (index .Labels "nodeName")}}pod
   labels:
     app: nse-icmp-responder
     "spiffe.io/spiffe-id": "true"


### PR DESCRIPTION
### Description

Sometimes `nodeName` is too long to be processed by spire

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>