### PR TITLE
Workaround for spiffe/spire#3032

### DIFF
--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -42,7 +42,7 @@ spec:
             - name: NSM_CONTAINER_IMAGES
               value: ghcr.io/networkservicemesh/ci/cmd-nsc:7fa20f1
             - name: NSM_INIT_CONTAINER_IMAGES
-              value: ghcr.io/networkservicemesh/ci/cmd-nsc-init:3b8d5ce
+              value: ghcr.io/networkservicemesh/cmd-nsc-init:v1.4.0
             - name: NSM_LABELS
               value: spiffe.io/spiffe-id:true
             - name: NSM_ENVS

--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -40,7 +40,7 @@ spec:
             - name: NSM_ANNOTATION
               value: networkservicemesh.io
             - name: NSM_CONTAINER_IMAGES
-              value: ghcr.io/networkservicemesh/ci/cmd-nsc:7fa20f1
+              value: ghcr.io/networkservicemesh/cmd-nsc:v1.4.0
             - name: NSM_INIT_CONTAINER_IMAGES
               value: ghcr.io/networkservicemesh/cmd-nsc-init:v1.4.0
             - name: NSM_LABELS

--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: admission-webhook-sa
       containers:
         - name: admission-webhook-k8s
-          image: ghcr.io/networkservicemesh/ci/cmd-admission-webhook-k8s:35ad46f
+          image: ghcr.io/networkservicemesh/cmd-admission-webhook-k8s:v1.4.0
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:

--- a/apps/forwarder-ovs/forwarder.yaml
+++ b/apps/forwarder-ovs/forwarder.yaml
@@ -18,7 +18,7 @@ spec:
       hostPID: true
       hostNetwork: true
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-forwarder-ovs:139d7b0
+        - image: ghcr.io/networkservicemesh/cmd-forwarder-ovs:v1.4.0
           imagePullPolicy: IfNotPresent
           name: forwarder-ovs
           securityContext:

--- a/apps/forwarder-sriov/forwarder.yaml
+++ b/apps/forwarder-sriov/forwarder.yaml
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-forwarder-sriov:f430db8
+        - image: ghcr.io/networkservicemesh/cmd-forwarder-sriov:v1.4.0
           imagePullPolicy: IfNotPresent
           name: forwarder-sriov
           securityContext:

--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-forwarder-vpp:fb804d6
+        - image: ghcr.io/networkservicemesh/cmd-forwarder-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           name: forwarder-vpp
           securityContext:

--- a/apps/nsc-kernel/nsc.yaml
+++ b/apps/nsc-kernel/nsc.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nsc
-          image: ghcr.io/networkservicemesh/ci/cmd-nsc:7fa20f1
+          image: ghcr.io/networkservicemesh/cmd-nsc:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nsc-memif/nsc.yaml
+++ b/apps/nsc-memif/nsc.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nsc
-          image: ghcr.io/networkservicemesh/ci/cmd-nsc-vpp:c4f7cbf
+          image: ghcr.io/networkservicemesh/cmd-nsc-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nsc-vfio/nsc.yaml
+++ b/apps/nsc-vfio/nsc.yaml
@@ -26,7 +26,7 @@ spec:
               mountPath: /dev/vfio
 
         - name: sidecar
-          image: ghcr.io/networkservicemesh/ci/cmd-nsc:7fa20f1
+          image: ghcr.io/networkservicemesh/cmd-nsc:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nse-firewall-vpp/nse.yaml
+++ b/apps/nse-firewall-vpp/nse.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-firewall-vpp:fdd5f37
+          image: ghcr.io/networkservicemesh/cmd-nse-firewall-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nse-kernel/nse.yaml
+++ b/apps/nse-kernel/nse.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nse-memif/nse.yaml
+++ b/apps/nse-memif/nse.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder-vpp:6bf643e
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nse-remote-vlan/nse-remote-vlan.yaml
+++ b/apps/nse-remote-vlan/nse-remote-vlan.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-remote-vlan:6052854
+          image: ghcr.io/networkservicemesh/cmd-nse-remote-vlan:v1.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5003

--- a/apps/nse-simple-vl3-docker/docker-compose.yaml
+++ b/apps/nse-simple-vl3-docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   nse-simple-vl3-docker:
-    image: ghcr.io/networkservicemesh/ci/cmd-nse-simple-vl3-docker:3e0b451
+    image: ghcr.io/networkservicemesh/cmd-nse-simple-vl3-docker:v1.4.0
     privileged: true
     container_name: nse-simple-vl3-docker
     restart: always

--- a/apps/nse-supplier-k8s/supplier.yaml
+++ b/apps/nse-supplier-k8s/supplier.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse-supplier
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-supplier-k8s:a06fdd6
+          image: ghcr.io/networkservicemesh/cmd-nse-supplier-k8s:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nse-vfio/nse.yaml
+++ b/apps/nse-vfio/nse.yaml
@@ -32,7 +32,7 @@ spec:
               mountPath: /dev/vfio
 
         - name: sidecar
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-vfio:7efdcb9
+          image: ghcr.io/networkservicemesh/cmd-nse-vfio:v1.4.0
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/nse-vl3-vpp/nse.yaml
+++ b/apps/nse-vl3-vpp/nse.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-vl3-vpp:912f2ae
+          image: ghcr.io/networkservicemesh/cmd-nse-vl3-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/apps/nse-vlan-vpp/nse.yaml
+++ b/apps/nse-vlan-vpp/nse.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-vlan-vpp:52e60a6
+          image: ghcr.io/networkservicemesh/cmd-nse-vlan-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/apps/nsmgr-proxy/nsmgr-proxy.yaml
+++ b/apps/nsmgr-proxy/nsmgr-proxy.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccount: nsmgr-proxy-sa
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-nsmgr-proxy:302cdb5
+        - image: ghcr.io/networkservicemesh/cmd-nsmgr-proxy:v1.4.0
           imagePullPolicy: IfNotPresent
           name: nsmgr-proxy
           ports:

--- a/apps/nsmgr-proxy/nsmgr-proxy.yaml
+++ b/apps/nsmgr-proxy/nsmgr-proxy.yaml
@@ -56,7 +56,7 @@ spec:
             limits:
               memory: 100Mi
               cpu: 400m
-        - image: ghcr.io/networkservicemesh/ci/cmd-map-ip-k8s:cddd5c9
+        - image: ghcr.io/networkservicemesh/cmd-map-ip-k8s:v1.4.0
           imagePullPolicy: IfNotPresent
           name: map-ip-k8s
           env:

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -81,7 +81,7 @@ spec:
               command: ["/bin/grpc-health-probe", "-spiffe", "-addr=:5001"]
             failureThreshold: 25
             periodSeconds: 5
-        - image: ghcr.io/networkservicemesh/ci/cmd-exclude-prefixes-k8s:796dfe2
+        - image: ghcr.io/networkservicemesh/cmd-exclude-prefixes-k8s:v1.4.0
           imagePullPolicy: IfNotPresent
           name: exclude-prefixes
           env:

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccount: nsmgr-sa
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-nsmgr:d69e521
+        - image: ghcr.io/networkservicemesh/cmd-nsmgr:v1.4.0
           imagePullPolicy: IfNotPresent
           name: nsmgr
           ports:

--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccountName: registry-k8s-sa
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-registry-k8s:d8fc424
+        - image: ghcr.io/networkservicemesh/cmd-registry-k8s:v1.4.0
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/registry-memory/registry-memory.yaml
+++ b/apps/registry-memory/registry-memory.yaml
@@ -16,7 +16,7 @@ spec:
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-registry-memory:ab5399e
+        - image: ghcr.io/networkservicemesh/cmd-registry-memory:v1.4.0
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/registry-proxy-dns/registry-proxy-dns.yaml
+++ b/apps/registry-proxy-dns/registry-proxy-dns.yaml
@@ -16,7 +16,7 @@ spec:
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-registry-proxy-dns:5e557fd
+        - image: ghcr.io/networkservicemesh/cmd-registry-proxy-dns:v1.4.0
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/vl3-ipam/vl3-ipam.yaml
+++ b/apps/vl3-ipam/vl3-ipam.yaml
@@ -16,7 +16,7 @@ spec:
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-ipam-vl3:29190bc
+        - image: ghcr.io/networkservicemesh/cmd-ipam-vl3:v1.4.0
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -31,7 +31,7 @@ kubectl create ns nsm-system
 2. Apply NSM resources for basic tests:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=v1.4.0
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -31,7 +31,7 @@ kubectl create ns nsm-system
 2. Apply NSM resources for basic tests:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/features/dns/README.md
+++ b/examples/features/dns/README.md
@@ -11,7 +11,7 @@ Make sure that you have completed steps from [features](../)
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -107,11 +107,11 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 resources:
 - dnsutils.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/dns/coredns-config-map.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/dns/coredns-config-map.yaml
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/dns/README.md
+++ b/examples/features/dns/README.md
@@ -11,7 +11,7 @@ Make sure that you have completed steps from [features](../)
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -107,11 +107,11 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 resources:
 - dnsutils.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/dns/coredns-config-map.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/dns/coredns-config-map.yaml
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/dual-stack/Kernel2Kernel_dual_stack/README.md
+++ b/examples/features/dual-stack/Kernel2Kernel_dual_stack/README.md
@@ -9,7 +9,7 @@ NSC and NSE are using the `kernel` mechanism to connect to its local forwarder.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources:
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/dual-stack/Kernel2Kernel_dual_stack/README.md
+++ b/examples/features/dual-stack/Kernel2Kernel_dual_stack/README.md
@@ -9,7 +9,7 @@ NSC and NSE are using the `kernel` mechanism to connect to its local forwarder.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources:
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/dual-stack/Kernel2Wireguard2Kernel_dual_stack/README.md
+++ b/examples/features/dual-stack/Kernel2Wireguard2Kernel_dual_stack/README.md
@@ -9,7 +9,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources:
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/dual-stack/Kernel2Wireguard2Kernel_dual_stack/README.md
+++ b/examples/features/dual-stack/Kernel2Wireguard2Kernel_dual_stack/README.md
@@ -9,7 +9,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources:
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/exclude-prefixes-client/README.md
+++ b/examples/features/exclude-prefixes-client/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -26,11 +26,11 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 resources:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/exclude-prefixes-client/test-client.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/exclude-prefixes-client/nsm-service-1.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/exclude-prefixes-client/nsm-service-2.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/exclude-prefixes-client/nse-kernel-1.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/exclude-prefixes-client/nse-kernel-2.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/test-client.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nsm-service-1.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nsm-service-2.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nse-kernel-1.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nse-kernel-2.yaml
 EOF
 ```
 

--- a/examples/features/exclude-prefixes-client/README.md
+++ b/examples/features/exclude-prefixes-client/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -26,11 +26,11 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 resources:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/test-client.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nsm-service-1.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nsm-service-2.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nse-kernel-1.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/exclude-prefixes-client/nse-kernel-2.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/exclude-prefixes-client/test-client.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/exclude-prefixes-client/nsm-service-1.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/exclude-prefixes-client/nsm-service-2.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/exclude-prefixes-client/nse-kernel-1.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/exclude-prefixes-client/nse-kernel-2.yaml
 EOF
 ```
 

--- a/examples/features/exclude-prefixes-client/nse-kernel-1.yaml
+++ b/examples/features/exclude-prefixes-client/nse-kernel-1.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/examples/features/exclude-prefixes-client/nse-kernel-2.yaml
+++ b/examples/features/exclude-prefixes-client/nse-kernel-2.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/examples/features/exclude-prefixes/README.md
+++ b/examples/features/exclude-prefixes/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/exclude-prefixes/README.md
+++ b/examples/features/exclude-prefixes/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/ipv6/Kernel2Kernel_ipv6/README.md
+++ b/examples/features/ipv6/Kernel2Kernel_ipv6/README.md
@@ -9,7 +9,7 @@ NSC and NSE are using the `kernel` mechanism to connect to its local forwarder.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/ipv6/Kernel2Kernel_ipv6/README.md
+++ b/examples/features/ipv6/Kernel2Kernel_ipv6/README.md
@@ -9,7 +9,7 @@ NSC and NSE are using the `kernel` mechanism to connect to its local forwarder.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/ipv6/Kernel2Wireguard2Kernel_ipv6/README.md
+++ b/examples/features/ipv6/Kernel2Wireguard2Kernel_ipv6/README.md
@@ -9,7 +9,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/ipv6/Kernel2Wireguard2Kernel_ipv6/README.md
+++ b/examples/features/ipv6/Kernel2Wireguard2Kernel_ipv6/README.md
@@ -9,7 +9,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,7 +30,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/ipv6/Kernel2Wireguard2Memif_ipv6/README.md
+++ b/examples/features/ipv6/Kernel2Wireguard2Memif_ipv6/README.md
@@ -10,7 +10,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,7 +31,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/ipv6/Kernel2Wireguard2Memif_ipv6/README.md
+++ b/examples/features/ipv6/Kernel2Wireguard2Memif_ipv6/README.md
@@ -10,7 +10,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,7 +31,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/ipv6/Memif2Memif_ipv6/README.md
+++ b/examples/features/ipv6/Memif2Memif_ipv6/README.md
@@ -8,7 +8,7 @@ NSC and NSE are using the `memif` mechanism to connect to its local forwarder.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -27,8 +27,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/ipv6/Memif2Memif_ipv6/README.md
+++ b/examples/features/ipv6/Memif2Memif_ipv6/README.md
@@ -8,7 +8,7 @@ NSC and NSE are using the `memif` mechanism to connect to its local forwarder.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -27,8 +27,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/ipv6/Memif2Wireguard2Kernel_ipv6/README.md
+++ b/examples/features/ipv6/Memif2Wireguard2Kernel_ipv6/README.md
@@ -11,7 +11,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,8 +30,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/ipv6/Memif2Wireguard2Kernel_ipv6/README.md
+++ b/examples/features/ipv6/Memif2Wireguard2Kernel_ipv6/README.md
@@ -11,7 +11,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,8 +30,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/ipv6/Memif2Wireguard2Memif_ipv6/README.md
+++ b/examples/features/ipv6/Memif2Wireguard2Memif_ipv6/README.md
@@ -9,7 +9,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -28,8 +28,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/ipv6/Memif2Wireguard2Memif_ipv6/README.md
+++ b/examples/features/ipv6/Memif2Wireguard2Memif_ipv6/README.md
@@ -9,7 +9,7 @@ Forwarders are using the `wireguard` mechanism to connect with each other.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -28,8 +28,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/jaeger/README.md
+++ b/examples/features/jaeger/README.md
@@ -84,7 +84,7 @@ kubectl wait -n observability --timeout=1m --for=condition=ready pod -l name=jae
 
 Apply Jaeger pod:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/jaeger?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/jaeger?ref=v1.4.0
 ```
 
 Wait for Jaeger pod status ready:
@@ -94,12 +94,12 @@ kubectl wait -n observability --timeout=1m --for=condition=ready pod -l app=jaeg
 
 Apply OpenTelemetry pod:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/opentelemetry?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/opentelemetry?ref=v1.4.0
 ```
 
 Apply Spire deployments (required for NSM system)
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0
 ```
 
 Wait for Spire pods status ready:
@@ -117,7 +117,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/nsm-system?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/nsm-system?ref=v1.4.0
 ```
 
 Wait for admission-webhook-k8s:

--- a/examples/features/jaeger/README.md
+++ b/examples/features/jaeger/README.md
@@ -84,7 +84,7 @@ kubectl wait -n observability --timeout=1m --for=condition=ready pod -l name=jae
 
 Apply Jaeger pod:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/jaeger?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/jaeger?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for Jaeger pod status ready:
@@ -94,12 +94,12 @@ kubectl wait -n observability --timeout=1m --for=condition=ready pod -l app=jaeg
 
 Apply OpenTelemetry pod:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/opentelemetry?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/opentelemetry?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Apply Spire deployments (required for NSM system)
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for Spire pods status ready:
@@ -117,7 +117,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/nsm-system?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/jaeger/nsm-system?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for admission-webhook-k8s:

--- a/examples/features/mutually-aware-nses/README.md
+++ b/examples/features/mutually-aware-nses/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -38,7 +38,7 @@ resources:
 - config-file-nse-1.yaml
 - config-file-nse-2.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/mutually-aware-nses/README.md
+++ b/examples/features/mutually-aware-nses/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -38,7 +38,7 @@ resources:
 - config-file-nse-1.yaml
 - config-file-nse-2.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/mutually-aware-nses/nse-1.yaml
+++ b/examples/features/mutually-aware-nses/nse-1.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NSM_CIDR_PREFIX

--- a/examples/features/mutually-aware-nses/nse-2.yaml
+++ b/examples/features/mutually-aware-nses/nse-2.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NSM_CIDR_PREFIX

--- a/examples/features/nse-composition/README.md
+++ b/examples/features/nse-composition/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,15 +30,15 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 resources:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/config-file.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/passthrough-1.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/passthrough-2.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/passthrough-3.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/nse-composition-ns.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/nse-composition/config-file.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/nse-composition/passthrough-1.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/nse-composition/passthrough-2.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/nse-composition/passthrough-3.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/nse-composition/nse-composition-ns.yaml
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/examples/features/nse-composition/nse-firewall?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/examples/features/nse-composition/nse-firewall?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -46,7 +46,7 @@ patchesStrategicMerge:
 configMapGenerator:
   - name: nginx-config
     files:
-      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/nginx.conf
+      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/nse-composition/nginx.conf
 EOF
 ```
 

--- a/examples/features/nse-composition/README.md
+++ b/examples/features/nse-composition/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -30,15 +30,15 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 resources:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/nse-composition/config-file.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/nse-composition/passthrough-1.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/nse-composition/passthrough-2.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/nse-composition/passthrough-3.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/nse-composition/nse-composition-ns.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/config-file.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/passthrough-1.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/passthrough-2.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/passthrough-3.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/nse-composition-ns.yaml
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/examples/features/nse-composition/nse-firewall?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/examples/features/nse-composition/nse-firewall?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -46,7 +46,7 @@ patchesStrategicMerge:
 configMapGenerator:
   - name: nginx-config
     files:
-      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/nse-composition/nginx.conf
+      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/nse-composition/nginx.conf
 EOF
 ```
 

--- a/examples/features/nse-composition/passthrough-1.yaml
+++ b/examples/features/nse-composition/passthrough-1.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-firewall-vpp:fdd5f37
+          image: ghcr.io/networkservicemesh/cmd-nse-firewall-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NSM_SERVICE_NAME

--- a/examples/features/nse-composition/passthrough-2.yaml
+++ b/examples/features/nse-composition/passthrough-2.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-firewall-vpp:fdd5f37
+          image: ghcr.io/networkservicemesh/cmd-nse-firewall-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NSM_SERVICE_NAME

--- a/examples/features/nse-composition/passthrough-3.yaml
+++ b/examples/features/nse-composition/passthrough-3.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-firewall-vpp:fdd5f37
+          image: ghcr.io/networkservicemesh/cmd-nse-firewall-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NSM_SERVICE_NAME

--- a/examples/features/opa/README.md
+++ b/examples/features/opa/README.md
@@ -19,7 +19,7 @@ Expected that Endpoint(in this case NSMgr) will fail the Request from the client
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -38,8 +38,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/opa/README.md
+++ b/examples/features/opa/README.md
@@ -19,7 +19,7 @@ Expected that Endpoint(in this case NSMgr) will fail the Request from the client
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -38,8 +38,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/features/policy-based-routing/README.md
+++ b/examples/features/policy-based-routing/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -36,7 +36,7 @@ resources:
 - client.yaml
 - config-file-nse.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/policy-based-routing/README.md
+++ b/examples/features/policy-based-routing/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -36,7 +36,7 @@ resources:
 - client.yaml
 - config-file-nse.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/features/scale-from-zero/README.md
+++ b/examples/features/scale-from-zero/README.md
@@ -20,7 +20,7 @@ thus saving cluster resources (see step 14).
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -100,8 +100,8 @@ kind: Kustomization
 namespace: $NAMESPACE
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -110,13 +110,13 @@ patchesStrategicMerge:
 configMapGenerator:
   - name: supplier-pod-template-configmap
     files:
-      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/scale-from-zero/pod-template.yaml
+      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/scale-from-zero/pod-template.yaml
 EOF
 ```
 
 6. Register network service:
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/scale-from-zero/autoscale-netsvc.yaml
+kubectl apply -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/scale-from-zero/autoscale-netsvc.yaml
 ```
 
 7. Deploy NSC and supplier:

--- a/examples/features/scale-from-zero/README.md
+++ b/examples/features/scale-from-zero/README.md
@@ -20,7 +20,7 @@ thus saving cluster resources (see step 14).
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -100,8 +100,8 @@ kind: Kustomization
 namespace: $NAMESPACE
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -110,13 +110,13 @@ patchesStrategicMerge:
 configMapGenerator:
   - name: supplier-pod-template-configmap
     files:
-      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/scale-from-zero/pod-template.yaml
+      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/scale-from-zero/pod-template.yaml
 EOF
 ```
 
 6. Register network service:
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/scale-from-zero/autoscale-netsvc.yaml
+kubectl apply -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/scale-from-zero/autoscale-netsvc.yaml
 ```
 
 7. Deploy NSC and supplier:

--- a/examples/features/scale-from-zero/pod-template.yaml
+++ b/examples/features/scale-from-zero/pod-template.yaml
@@ -12,7 +12,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: nse-icmp-responder
-      image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+      image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
       imagePullPolicy: IfNotPresent
       env:
         - name: SPIFFE_ENDPOINT_SOCKET

--- a/examples/features/select-forwarder/README.md
+++ b/examples/features/select-forwarder/README.md
@@ -25,7 +25,7 @@ kubectl create ns ns-select-forwarder
 Apply example resources:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/select-forwarder?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/select-forwarder?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for applications ready:

--- a/examples/features/select-forwarder/README.md
+++ b/examples/features/select-forwarder/README.md
@@ -25,7 +25,7 @@ kubectl create ns ns-select-forwarder
 Apply example resources:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/select-forwarder?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/select-forwarder?ref=v1.4.0
 ```
 
 Wait for applications ready:

--- a/examples/features/select-forwarder/forwarder.yaml
+++ b/examples/features/select-forwarder/forwarder.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-forwarder-vpp:fb804d6
+        - image: ghcr.io/networkservicemesh/cmd-forwarder-vpp:v1.4.0
           imagePullPolicy: IfNotPresent
           name: my-forwarder-vpp
           securityContext:

--- a/examples/features/vl3-basic/README.md
+++ b/examples/features/vl3-basic/README.md
@@ -24,7 +24,7 @@ kubectl create ns ns-vl3
 2. Deploy nsc and vl3 nses (See at `kustomization.yaml`):
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-basic?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-basic?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 3. Find all nscs:

--- a/examples/features/vl3-basic/README.md
+++ b/examples/features/vl3-basic/README.md
@@ -24,7 +24,7 @@ kubectl create ns ns-vl3
 2. Deploy nsc and vl3 nses (See at `kustomization.yaml`):
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-basic?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-basic?ref=v1.4.0
 ```
 
 3. Find all nscs:

--- a/examples/features/vl3-basic/kustomization.yaml
+++ b/examples/features/vl3-basic/kustomization.yaml
@@ -5,10 +5,10 @@ kind: Kustomization
 namespace: ns-vl3
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vl3-vpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vl3-vpp?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=v1.4.0
 
 patchesStrategicMerge:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/vl3-basic/nsc-patch.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/vl3-basic/nse-patch.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-basic/nsc-patch.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-basic/nse-patch.yaml

--- a/examples/features/vl3-basic/kustomization.yaml
+++ b/examples/features/vl3-basic/kustomization.yaml
@@ -5,10 +5,10 @@ kind: Kustomization
 namespace: ns-vl3
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vl3-vpp?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vl3-vpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-basic/nsc-patch.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-basic/nse-patch.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/vl3-basic/nsc-patch.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/vl3-basic/nse-patch.yaml

--- a/examples/features/vl3-scale-from-zero/README.md
+++ b/examples/features/vl3-scale-from-zero/README.md
@@ -14,7 +14,7 @@ kubectl create ns ns-vl3
 
 2. Deploy NSC and supplier:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-scale-from-zero?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-scale-from-zero?ref=v1.4.0
 ```
 
 3. Wait for applications ready:

--- a/examples/features/vl3-scale-from-zero/README.md
+++ b/examples/features/vl3-scale-from-zero/README.md
@@ -14,7 +14,7 @@ kubectl create ns ns-vl3
 
 2. Deploy NSC and supplier:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-scale-from-zero?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/features/vl3-scale-from-zero?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 3. Wait for applications ready:

--- a/examples/features/vl3-scale-from-zero/kustomization.yaml
+++ b/examples/features/vl3-scale-from-zero/kustomization.yaml
@@ -5,13 +5,13 @@ kind: Kustomization
 namespace: ns-vl3
 
 resources:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-scale-from-zero/autoscale-netsvc.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-scale-from-zero/vl3-netsvc.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/vl3-scale-from-zero/autoscale-netsvc.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/vl3-scale-from-zero/vl3-netsvc.yaml
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - nsc-patch.yaml
@@ -20,4 +20,4 @@ patchesStrategicMerge:
 configMapGenerator:
   - name: supplier-pod-template-configmap
     files:
-      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-scale-from-zero/pod-template.yaml
+      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/vl3-scale-from-zero/pod-template.yaml

--- a/examples/features/vl3-scale-from-zero/kustomization.yaml
+++ b/examples/features/vl3-scale-from-zero/kustomization.yaml
@@ -5,13 +5,13 @@ kind: Kustomization
 namespace: ns-vl3
 
 resources:
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/vl3-scale-from-zero/autoscale-netsvc.yaml
-- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/vl3-scale-from-zero/vl3-netsvc.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-scale-from-zero/autoscale-netsvc.yaml
+- https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-scale-from-zero/vl3-netsvc.yaml
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/vl3-ipam?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=v1.4.0
 
 patchesStrategicMerge:
 - nsc-patch.yaml
@@ -20,4 +20,4 @@ patchesStrategicMerge:
 configMapGenerator:
   - name: supplier-pod-template-configmap
     files:
-      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/vl3-scale-from-zero/pod-template.yaml
+      - https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/vl3-scale-from-zero/pod-template.yaml

--- a/examples/features/vl3-scale-from-zero/pod-template.yaml
+++ b/examples/features/vl3-scale-from-zero/pod-template.yaml
@@ -11,7 +11,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: nse
-      image: ghcr.io/networkservicemesh/ci/cmd-nse-vl3-vpp:912f2ae
+      image: ghcr.io/networkservicemesh/cmd-nse-vl3-vpp:v1.4.0
       imagePullPolicy: IfNotPresent
       env:
         - name: SPIFFE_ENDPOINT_SOCKET

--- a/examples/features/webhook-smartvf/README.md
+++ b/examples/features/webhook-smartvf/README.md
@@ -18,7 +18,7 @@ kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -104,7 +104,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 resources:
 - postgres-cl.yaml

--- a/examples/features/webhook-smartvf/README.md
+++ b/examples/features/webhook-smartvf/README.md
@@ -18,7 +18,7 @@ kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -104,7 +104,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 resources:
 - postgres-cl.yaml

--- a/examples/features/webhook/README.md
+++ b/examples/features/webhook/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [features](../)
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -80,7 +80,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 resources:
 - client.yaml

--- a/examples/features/webhook/README.md
+++ b/examples/features/webhook/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [features](../)
 
 1. Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/features/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/features/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -80,7 +80,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 resources:
 - client.yaml

--- a/examples/heal/dataplane-interrupt/README.md
+++ b/examples/heal/dataplane-interrupt/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/dataplane-interrupt/README.md
+++ b/examples/heal/dataplane-interrupt/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-forwarder-death/README.md
+++ b/examples/heal/local-forwarder-death/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-forwarder-death/README.md
+++ b/examples/heal/local-forwarder-death/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-forwarder-remote-forwarder/README.md
+++ b/examples/heal/local-forwarder-remote-forwarder/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-forwarder-remote-forwarder/README.md
+++ b/examples/heal/local-forwarder-remote-forwarder/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nse-death/README.md
+++ b/examples/heal/local-nse-death/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nse-death/README.md
+++ b/examples/heal/local-nse-death/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsm-system-restart/README.md
+++ b/examples/heal/local-nsm-system-restart/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic).
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -121,7 +121,7 @@ kubectl delete ns nsm-system
 kubectl create ns nsm-system
 ```
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=v1.4.0
 ```
 
 Ping from NSC to NSE:

--- a/examples/heal/local-nsm-system-restart/README.md
+++ b/examples/heal/local-nsm-system-restart/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic).
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -121,7 +121,7 @@ kubectl delete ns nsm-system
 kubectl create ns nsm-system
 ```
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Ping from NSC to NSE:

--- a/examples/heal/local-nsmgr-local-forwarder-memif/README.md
+++ b/examples/heal/local-nsmgr-local-forwarder-memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-local-forwarder-memif/README.md
+++ b/examples/heal/local-nsmgr-local-forwarder-memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-local-nse-memif/README.md
+++ b/examples/heal/local-nsmgr-local-nse-memif/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-local-nse-memif/README.md
+++ b/examples/heal/local-nsmgr-local-nse-memif/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-remote-nsmgr/README.md
+++ b/examples/heal/local-nsmgr-remote-nsmgr/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-remote-nsmgr/README.md
+++ b/examples/heal/local-nsmgr-remote-nsmgr/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-restart/README.md
+++ b/examples/heal/local-nsmgr-restart/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/local-nsmgr-restart/README.md
+++ b/examples/heal/local-nsmgr-restart/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-local-endpoint/README.md
+++ b/examples/heal/registry-local-endpoint/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-local-endpoint/README.md
+++ b/examples/heal/registry-local-endpoint/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-remote-forwarder/README.md
+++ b/examples/heal/registry-remote-forwarder/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-remote-forwarder/README.md
+++ b/examples/heal/registry-remote-forwarder/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-remote-nsmgr/README.md
+++ b/examples/heal/registry-remote-nsmgr/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-remote-nsmgr/README.md
+++ b/examples/heal/registry-remote-nsmgr/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/registry-restart/README.md
+++ b/examples/heal/registry-restart/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -134,7 +134,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesJson6902:
 - target:

--- a/examples/heal/registry-restart/README.md
+++ b/examples/heal/registry-restart/README.md
@@ -12,7 +12,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -31,8 +31,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -134,7 +134,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesJson6902:
 - target:

--- a/examples/heal/remote-forwarder-death-ip/README.md
+++ b/examples/heal/remote-forwarder-death-ip/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-forwarder-death-ip/README.md
+++ b/examples/heal/remote-forwarder-death-ip/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-forwarder-death/README.md
+++ b/examples/heal/remote-forwarder-death/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-forwarder-death/README.md
+++ b/examples/heal/remote-forwarder-death/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nse-death-ip/README.md
+++ b/examples/heal/remote-nse-death-ip/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nse-death-ip/README.md
+++ b/examples/heal/remote-nse-death-ip/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nse-death/README.md
+++ b/examples/heal/remote-nse-death/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nse-death/README.md
+++ b/examples/heal/remote-nse-death/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nsm-system-restart-memif-ip/README.md
+++ b/examples/heal/remote-nsm-system-restart-memif-ip/README.md
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -131,7 +131,7 @@ kubectl delete ns nsm-system
 kubectl create ns nsm-system
 ```
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Ping from NSC to NSE:

--- a/examples/heal/remote-nsm-system-restart-memif-ip/README.md
+++ b/examples/heal/remote-nsm-system-restart-memif-ip/README.md
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -131,7 +131,7 @@ kubectl delete ns nsm-system
 kubectl create ns nsm-system
 ```
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=v1.4.0
 ```
 
 Ping from NSC to NSE:

--- a/examples/heal/remote-nsmgr-death/README.md
+++ b/examples/heal/remote-nsmgr-death/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -124,7 +124,7 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsmgr.yaml
@@ -167,7 +167,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -223,7 +223,7 @@ kubectl exec ${NEW_NSE} -n ${NAMESPACE} -- ping -c 4 172.16.1.103
 
 Restore NSMgr setup:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0 -n nsm-system
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=aac4a0939f1fed428f99761b827e0ba2c876680b -n nsm-system
 ```
 
 Delete ns:

--- a/examples/heal/remote-nsmgr-death/README.md
+++ b/examples/heal/remote-nsmgr-death/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml
@@ -124,7 +124,7 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsmgr.yaml
@@ -167,7 +167,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -223,7 +223,7 @@ kubectl exec ${NEW_NSE} -n ${NAMESPACE} -- ping -c 4 172.16.1.103
 
 Restore NSMgr setup:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533 -n nsm-system
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0 -n nsm-system
 ```
 
 Delete ns:

--- a/examples/heal/remote-nsmgr-remote-endpoint/README.md
+++ b/examples/heal/remote-nsmgr-remote-endpoint/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nsmgr-remote-endpoint/README.md
+++ b/examples/heal/remote-nsmgr-remote-endpoint/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nsmgr-restart-ip/README.md
+++ b/examples/heal/remote-nsmgr-restart-ip/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nsmgr-restart-ip/README.md
+++ b/examples/heal/remote-nsmgr-restart-ip/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nsmgr-restart/README.md
+++ b/examples/heal/remote-nsmgr-restart/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/heal/remote-nsmgr-restart/README.md
+++ b/examples/heal/remote-nsmgr-restart/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/heal/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/heal/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/spire/README.md
+++ b/examples/interdomain/spire/README.md
@@ -31,7 +31,7 @@ export KUBECONFIG=$KUBECONFIG1
 ```
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster1?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster1?ref=v1.4.0
 ```
 
 Wait for PODs status ready:
@@ -48,7 +48,7 @@ export KUBECONFIG=$KUBECONFIG2
 ```
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster2?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster2?ref=v1.4.0
 ```
 
 Wait for PODs status ready:
@@ -65,7 +65,7 @@ export KUBECONFIG=$KUBECONFIG3
 ```
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster3?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster3?ref=v1.4.0
 ```
 
 Wait for PODs status ready:

--- a/examples/interdomain/spire/README.md
+++ b/examples/interdomain/spire/README.md
@@ -31,7 +31,7 @@ export KUBECONFIG=$KUBECONFIG1
 ```
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster1?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster1?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for PODs status ready:
@@ -48,7 +48,7 @@ export KUBECONFIG=$KUBECONFIG2
 ```
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster2?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster2?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for PODs status ready:
@@ -65,7 +65,7 @@ export KUBECONFIG=$KUBECONFIG3
 ```
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster3?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/interdomain/spire/cluster3?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for PODs status ready:

--- a/examples/interdomain/usecases/FloatingKernel2Vxlan2Kernel/README.md
+++ b/examples/interdomain/usecases/FloatingKernel2Vxlan2Kernel/README.md
@@ -24,7 +24,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -38,7 +38,7 @@ kind: Kustomization
 namespace: ${NAMESPACE1}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -94,7 +94,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -108,7 +108,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/FloatingKernel2Vxlan2Kernel/README.md
+++ b/examples/interdomain/usecases/FloatingKernel2Vxlan2Kernel/README.md
@@ -24,7 +24,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -38,7 +38,7 @@ kind: Kustomization
 namespace: ${NAMESPACE1}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -94,7 +94,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -108,7 +108,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
+++ b/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
@@ -27,7 +27,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -67,7 +67,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -81,7 +81,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
+++ b/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/README.md
@@ -27,7 +27,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -67,7 +67,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -81,7 +81,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/nse.yaml
+++ b/examples/interdomain/usecases/FloatingKernel2Wireguard2Kernel/nse.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: nse
-          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:61e5955
+          image: ghcr.io/networkservicemesh/cmd-nse-icmp-responder:v1.4.0
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET

--- a/examples/interdomain/usecases/Kernel2Vxlan2Kernel/README.md
+++ b/examples/interdomain/usecases/Kernel2Vxlan2Kernel/README.md
@@ -21,7 +21,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -35,7 +35,7 @@ kind: Kustomization
 namespace: ${NAMESPACE1}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -82,7 +82,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -96,7 +96,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/Kernel2Vxlan2Kernel/README.md
+++ b/examples/interdomain/usecases/Kernel2Vxlan2Kernel/README.md
@@ -21,7 +21,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -35,7 +35,7 @@ kind: Kustomization
 namespace: ${NAMESPACE1}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -82,7 +82,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -96,7 +96,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/interdomain/usecases/Kernel2Wireguard2Kernel/README.md
@@ -21,7 +21,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -35,7 +35,7 @@ kind: Kustomization
 namespace: ${NAMESPACE1}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -86,7 +86,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -100,7 +100,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/interdomain/usecases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/interdomain/usecases/Kernel2Wireguard2Kernel/README.md
@@ -21,7 +21,7 @@ export KUBECONFIG=$KUBECONFIG2
 
 Create test namespace:
 ```bash
-NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE1=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE1=${NAMESPACE1:10}
 ```
 
@@ -35,7 +35,7 @@ kind: Kustomization
 namespace: ${NAMESPACE1}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml
@@ -86,7 +86,7 @@ export KUBECONFIG=$KUBECONFIG1
 
 Create test namespace:
 ```bash
-NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/interdomain/usecases/namespace.yaml)[0])
+NAMESPACE2=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/interdomain/usecases/namespace.yaml)[0])
 NAMESPACE2=${NAMESPACE2:10}
 ```
 
@@ -100,7 +100,7 @@ kind: Kustomization
 namespace: ${NAMESPACE2}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/k8s_monolith/README.md
+++ b/examples/k8s_monolith/README.md
@@ -29,7 +29,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/cluster-configuration?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/cluster-configuration?ref=v1.4.0
 ```
 
 Wait for registry service exposing:

--- a/examples/k8s_monolith/README.md
+++ b/examples/k8s_monolith/README.md
@@ -29,7 +29,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/cluster-configuration?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/cluster-configuration?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for registry service exposing:

--- a/examples/k8s_monolith/docker/README.md
+++ b/examples/k8s_monolith/docker/README.md
@@ -21,7 +21,7 @@ EOF
 
 Download docker-compose base file:
 ```bash
-curl https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/apps/nse-simple-vl3-docker/docker-compose.yaml -o docker-compose.yaml
+curl https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/apps/nse-simple-vl3-docker/docker-compose.yaml -o docker-compose.yaml
 ```
 
 Run docker-nse:

--- a/examples/k8s_monolith/docker/README.md
+++ b/examples/k8s_monolith/docker/README.md
@@ -21,7 +21,7 @@ EOF
 
 Download docker-compose base file:
 ```bash
-curl https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/apps/nse-simple-vl3-docker/docker-compose.yaml -o docker-compose.yaml
+curl https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/apps/nse-simple-vl3-docker/docker-compose.yaml -o docker-compose.yaml
 ```
 
 Run docker-nse:

--- a/examples/k8s_monolith/spire/README.md
+++ b/examples/k8s_monolith/spire/README.md
@@ -8,7 +8,7 @@ Docker container uses binary spire server.
 1. Setup spire on the k8s cluster
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/spire?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/spire?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for PODs status ready:

--- a/examples/k8s_monolith/spire/README.md
+++ b/examples/k8s_monolith/spire/README.md
@@ -8,7 +8,7 @@ Docker container uses binary spire server.
 1. Setup spire on the k8s cluster
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/spire?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/k8s_monolith/spire?ref=v1.4.0
 ```
 
 Wait for PODs status ready:

--- a/examples/k8s_monolith/usecases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/k8s_monolith/usecases/Kernel2Wireguard2Kernel/README.md
@@ -11,7 +11,7 @@ Make sure that you have completed steps from [k8s_monolith](../../)
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/k8s_monolith/usecases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/k8s_monolith/usecases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -25,7 +25,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/k8s_monolith/usecases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/k8s_monolith/usecases/Kernel2Wireguard2Kernel/README.md
@@ -11,7 +11,7 @@ Make sure that you have completed steps from [k8s_monolith](../../)
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/k8s_monolith/usecases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/k8s_monolith/usecases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -25,7 +25,7 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -22,7 +22,7 @@ kubectl create ns nsm-system
 2. Apply NSM resources for basic tests:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/memory?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/memory?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -22,7 +22,7 @@ kubectl create ns nsm-system
 2. Apply NSM resources for basic tests:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/memory?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/memory?ref=v1.4.0
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/multiforwarder/README.md
+++ b/examples/multiforwarder/README.md
@@ -41,7 +41,7 @@ kubectl create ns nsm-system
 
 2. Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multiforwarder?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multiforwarder?ref=v1.4.0
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/multiforwarder/README.md
+++ b/examples/multiforwarder/README.md
@@ -41,7 +41,7 @@ kubectl create ns nsm-system
 
 2. Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multiforwarder?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multiforwarder?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/nsm_istio/nse-auto-scale/kustomization.yaml
+++ b/examples/nsm_istio/nse-auto-scale/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-supplier.yaml

--- a/examples/nsm_istio/nse-auto-scale/kustomization.yaml
+++ b/examples/nsm_istio/nse-auto-scale/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-supplier-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-supplier.yaml

--- a/examples/nsm_istio/nse-auto-scale/pod-template.yaml
+++ b/examples/nsm_istio/nse-auto-scale/pod-template.yaml
@@ -11,7 +11,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: nse
-      image: ghcr.io/networkservicemesh/ci/cmd-nse-istio-proxy:a7fe6f2
+      image: ghcr.io/networkservicemesh/cmd-nse-istio-proxy:v1.4.0
       imagePullPolicy: IfNotPresent
       env:
         - name: SPIFFE_ENDPOINT_SOCKET

--- a/examples/nsm_istio/nsm/cluster1/kustomization.yaml
+++ b/examples/nsm_istio/nsm/cluster1/kustomization.yaml
@@ -5,12 +5,12 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=v1.4.0
 
 resources:
   - namespace.yaml

--- a/examples/nsm_istio/nsm/cluster1/kustomization.yaml
+++ b/examples/nsm_istio/nsm/cluster1/kustomization.yaml
@@ -5,12 +5,12 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 resources:
   - namespace.yaml

--- a/examples/nsm_istio/nsm/cluster2/kustomization.yaml
+++ b/examples/nsm_istio/nsm/cluster2/kustomization.yaml
@@ -5,12 +5,12 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsmgr-proxy.yaml

--- a/examples/nsm_istio/nsm/cluster2/kustomization.yaml
+++ b/examples/nsm_istio/nsm/cluster2/kustomization.yaml
@@ -5,12 +5,12 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-k8s?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/registry-proxy-dns?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsmgr-proxy?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/admission-webhook-k8s?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsmgr-proxy.yaml

--- a/examples/nsm_istio/spire/cluster1/kustomization.yaml
+++ b/examples/nsm_istio/spire/cluster1/kustomization.yaml
@@ -23,4 +23,4 @@ configMapGenerator:
 
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=aac4a0939f1fed428f99761b827e0ba2c876680b

--- a/examples/nsm_istio/spire/cluster1/kustomization.yaml
+++ b/examples/nsm_istio/spire/cluster1/kustomization.yaml
@@ -23,4 +23,4 @@ configMapGenerator:
 
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0

--- a/examples/nsm_istio/spire/cluster2/kustomization.yaml
+++ b/examples/nsm_istio/spire/cluster2/kustomization.yaml
@@ -22,4 +22,4 @@ configMapGenerator:
     - k8s-workload-registrar.conf
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0

--- a/examples/nsm_istio/spire/cluster2/kustomization.yaml
+++ b/examples/nsm_istio/spire/cluster2/kustomization.yaml
@@ -22,4 +22,4 @@ configMapGenerator:
     - k8s-workload-registrar.conf
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=aac4a0939f1fed428f99761b827e0ba2c876680b

--- a/examples/observability/jaeger-and-prometheus/README.md
+++ b/examples/observability/jaeger-and-prometheus/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to setup Open Telemetry Collector with Jaeger and 
 ## Run
 Apply Jaeger, Prometheus and OpenTelemetry Collector:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for OpenTelemetry Collector POD status ready:
@@ -21,7 +21,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus/nsm-system?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus/nsm-system?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for admission-webhook-k8s:
@@ -32,7 +32,7 @@ kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -58,7 +58,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/observability/jaeger-and-prometheus/README.md
+++ b/examples/observability/jaeger-and-prometheus/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to setup Open Telemetry Collector with Jaeger and 
 ## Run
 Apply Jaeger, Prometheus and OpenTelemetry Collector:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus?ref=v1.4.0
 ```
 
 Wait for OpenTelemetry Collector POD status ready:
@@ -21,7 +21,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus/nsm-system?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/observability/jaeger-and-prometheus/nsm-system?ref=v1.4.0
 ```
 
 Wait for admission-webhook-k8s:
@@ -32,7 +32,7 @@ kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -58,7 +58,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/ovs/README.md
+++ b/examples/ovs/README.md
@@ -43,7 +43,7 @@ kubectl create ns nsm-system
 2. Apply NSM resources for basic tests:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/ovs?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/ovs?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/ovs/README.md
+++ b/examples/ovs/README.md
@@ -43,7 +43,7 @@ kubectl create ns nsm-system
 2. Apply NSM resources for basic tests:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/ovs?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/ovs?ref=v1.4.0
 ```
 
 3. Wait for admission-webhook-k8s:

--- a/examples/remotevlan/rvlanovs/README.md
+++ b/examples/remotevlan/rvlanovs/README.md
@@ -17,7 +17,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Deploy the forwarder:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=v1.4.0
 ```
 
 Wait forwarder to start:
@@ -31,5 +31,5 @@ kubectl -n nsm-system wait --for=condition=ready --timeout=2m pod -l app=forward
 Delete the forwarder:
 
 ```bash
-kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=v1.4.0
 ```

--- a/examples/remotevlan/rvlanovs/README.md
+++ b/examples/remotevlan/rvlanovs/README.md
@@ -17,7 +17,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Deploy the forwarder:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait forwarder to start:
@@ -31,5 +31,5 @@ kubectl -n nsm-system wait --for=condition=ready --timeout=2m pod -l app=forward
 Delete the forwarder:
 
 ```bash
-kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=v1.4.0
+kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanovs?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```

--- a/examples/remotevlan/rvlanovs/kustomization.yaml
+++ b/examples/remotevlan/rvlanovs/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-ovs?ref=v1.4.0
+  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-ovs?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 configMapGenerator:
   - name: device-selector

--- a/examples/remotevlan/rvlanovs/kustomization.yaml
+++ b/examples/remotevlan/rvlanovs/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-ovs?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-ovs?ref=v1.4.0
 
 configMapGenerator:
   - name: device-selector

--- a/examples/remotevlan/rvlanvpp/README.md
+++ b/examples/remotevlan/rvlanvpp/README.md
@@ -17,7 +17,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Deploy the forwarder:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait forwarder to start:
@@ -31,5 +31,5 @@ kubectl -n nsm-system wait --for=condition=ready --timeout=2m pod -l app=forward
 Delete the forwarder:
 
 ```bash
-kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=v1.4.0
+kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```

--- a/examples/remotevlan/rvlanvpp/README.md
+++ b/examples/remotevlan/rvlanvpp/README.md
@@ -17,7 +17,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Deploy the forwarder:
 
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=v1.4.0
 ```
 
 Wait forwarder to start:
@@ -31,5 +31,5 @@ kubectl -n nsm-system wait --for=condition=ready --timeout=2m pod -l app=forward
 Delete the forwarder:
 
 ```bash
-kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl delete -k https://github.com/networkservicemesh/deployments-k8s/examples/remotevlan/rvlanvpp?ref=v1.4.0
 ```

--- a/examples/remotevlan/rvlanvpp/kustomization.yaml
+++ b/examples/remotevlan/rvlanvpp/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=v1.4.0
 
 configMapGenerator:
   - name: device-selector

--- a/examples/remotevlan/rvlanvpp/kustomization.yaml
+++ b/examples/remotevlan/rvlanvpp/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: nsm-system
 
 bases:
-  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=v1.4.0
+  - https://github.com/networkservicemesh/deployments-k8s/apps/forwarder-vpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 configMapGenerator:
   - name: device-selector

--- a/examples/spire/README.md
+++ b/examples/spire/README.md
@@ -4,7 +4,7 @@
 
 To apply spire deployments following the next command:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0
 ```
 
 Wait for PODs status ready:

--- a/examples/spire/README.md
+++ b/examples/spire/README.md
@@ -4,7 +4,7 @@
 
 To apply spire deployments following the next command:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 Wait for PODs status ready:

--- a/examples/spire/agent-daemonset.yaml
+++ b/examples/spire/agent-daemonset.yaml
@@ -28,6 +28,13 @@ spec:
           image: gcr.io/spiffe-io/wait-for-it
           imagePullPolicy: IfNotPresent
           args: ["-t", "30", "spire-server:8081"]
+        - name: init-bundle
+          # Another init container with the same wait-for-it image to
+          # provide workaround for https://github.com/spiffe/spire/issues/3032
+          # It checks if the bundle is in place and ready to be parsed or not.
+          image: gcr.io/spiffe-io/wait-for-it
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', "t=0; until [ -f /run/spire/bundle/bundle.crt 2>&1 ] || [ $t -eq 5 ]; do t=`expr $t + 1`; sleep 1; done"]
       containers:
         - name: spire-agent
           image: gcr.io/spiffe-io/spire-agent:1.2.3

--- a/examples/sriov/README.md
+++ b/examples/sriov/README.md
@@ -36,7 +36,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/sriov?ref=v1.4.0
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/sriov?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 ```
 
 ## Cleanup

--- a/examples/sriov/README.md
+++ b/examples/sriov/README.md
@@ -36,7 +36,7 @@ kubectl create ns nsm-system
 
 Apply NSM resources for basic tests:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/sriov?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/sriov?ref=v1.4.0
 ```
 
 ## Cleanup

--- a/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
@@ -6,7 +6,7 @@ This example shows that local kernel connection and VFIO connection can be setup
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -41,10 +41,10 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
@@ -6,7 +6,7 @@ This example shows that local kernel connection and VFIO connection can be setup
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -41,10 +41,10 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Kernel2Kernel/README.md
+++ b/examples/use-cases/Kernel2Kernel/README.md
@@ -19,7 +19,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -40,7 +40,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Kernel/README.md
+++ b/examples/use-cases/Kernel2Kernel/README.md
@@ -19,7 +19,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -40,7 +40,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2KernelVLAN/README.md
+++ b/examples/use-cases/Kernel2KernelVLAN/README.md
@@ -16,7 +16,7 @@ hugepage, so in this case NSE pod should be created with memory limit > 2.2 GB.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,8 +35,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vlan-vpp?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vlan-vpp?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Kernel2KernelVLAN/README.md
+++ b/examples/use-cases/Kernel2KernelVLAN/README.md
@@ -16,7 +16,7 @@ hugepage, so in this case NSE pod should be created with memory limit > 2.2 GB.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,8 +35,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vlan-vpp?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vlan-vpp?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Kernel2Memif/README.md
+++ b/examples/use-cases/Kernel2Memif/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,7 +35,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Memif/README.md
+++ b/examples/use-cases/Kernel2Memif/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,7 +35,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2RVlanBreakout/README.md
+++ b/examples/use-cases/Kernel2RVlanBreakout/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Create test namespace:
 
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 

--- a/examples/use-cases/Kernel2RVlanBreakout/README.md
+++ b/examples/use-cases/Kernel2RVlanBreakout/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Create test namespace:
 
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 

--- a/examples/use-cases/Kernel2RVlanInternal/README.md
+++ b/examples/use-cases/Kernel2RVlanInternal/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Create test namespace:
 
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 

--- a/examples/use-cases/Kernel2RVlanInternal/README.md
+++ b/examples/use-cases/Kernel2RVlanInternal/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Create test namespace:
 
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 

--- a/examples/use-cases/Kernel2RVlanMultiNS/README.md
+++ b/examples/use-cases/Kernel2RVlanMultiNS/README.md
@@ -13,9 +13,9 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Create test namespace:
 
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 FIRST_NAMESPACE=${NAMESPACE:10}
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 SECOND_NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -236,7 +236,7 @@ resources:
 - third-client.yaml
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-remote-vlan?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-remote-vlan?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 nameSuffix: -bg
 

--- a/examples/use-cases/Kernel2RVlanMultiNS/README.md
+++ b/examples/use-cases/Kernel2RVlanMultiNS/README.md
@@ -13,9 +13,9 @@ Make sure that you have completed steps from [remotevlan](../../remotevlan) setu
 Create test namespace:
 
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 FIRST_NAMESPACE=${NAMESPACE:10}
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 SECOND_NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -236,7 +236,7 @@ resources:
 - third-client.yaml
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-remote-vlan?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-remote-vlan?ref=v1.4.0
 
 nameSuffix: -bg
 

--- a/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
@@ -6,7 +6,7 @@ This example shows that remote kernel over VXLAN connection and VFIO connection 
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -41,10 +41,10 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
@@ -6,7 +6,7 @@ This example shows that remote kernel over VXLAN connection and VFIO connection 
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -41,10 +41,10 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Kernel2Vxlan2Kernel/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,7 +34,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Vxlan2Kernel/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,7 +34,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Vxlan2Memif/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Memif/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,7 +35,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Vxlan2Memif/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Memif/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,7 +35,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Kernel/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,7 +34,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Kernel/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,7 +34,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Wireguard2Memif/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Memif/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,7 +35,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Kernel2Wireguard2Memif/README.md
+++ b/examples/use-cases/Kernel2Wireguard2Memif/README.md
@@ -14,7 +14,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -35,7 +35,7 @@ namespace: ${NAMESPACE}
 resources: 
 - client.yaml
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse.yaml

--- a/examples/use-cases/Memif2Kernel/README.md
+++ b/examples/use-cases/Memif2Kernel/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Kernel/README.md
+++ b/examples/use-cases/Memif2Kernel/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Memif/README.md
+++ b/examples/use-cases/Memif2Memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Memif/README.md
+++ b/examples/use-cases/Memif2Memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Vxlan2Kernel/README.md
+++ b/examples/use-cases/Memif2Vxlan2Kernel/README.md
@@ -15,7 +15,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,8 +34,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Vxlan2Kernel/README.md
+++ b/examples/use-cases/Memif2Vxlan2Kernel/README.md
@@ -15,7 +15,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,8 +34,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Vxlan2Memif/README.md
+++ b/examples/use-cases/Memif2Vxlan2Memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Vxlan2Memif/README.md
+++ b/examples/use-cases/Memif2Vxlan2Memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Memif2Wireguard2Kernel/README.md
@@ -15,7 +15,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,8 +34,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Wireguard2Kernel/README.md
+++ b/examples/use-cases/Memif2Wireguard2Kernel/README.md
@@ -15,7 +15,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -34,8 +34,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Wireguard2Memif/README.md
+++ b/examples/use-cases/Memif2Wireguard2Memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/Memif2Wireguard2Memif/README.md
+++ b/examples/use-cases/Memif2Wireguard2Memif/README.md
@@ -13,7 +13,7 @@ Make sure that you have completed steps from [basic](../../basic) or [memory](..
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -32,8 +32,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-memif?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nsc.yaml

--- a/examples/use-cases/SmartVF2SmartVF/README.md
+++ b/examples/use-cases/SmartVF2SmartVF/README.md
@@ -10,7 +10,7 @@ Make sure that you have completed steps from [ovs](../../ovs) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -24,8 +24,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 
 patchesStrategicMerge:

--- a/examples/use-cases/SmartVF2SmartVF/README.md
+++ b/examples/use-cases/SmartVF2SmartVF/README.md
@@ -10,7 +10,7 @@ Make sure that you have completed steps from [ovs](../../ovs) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -24,8 +24,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
 
 
 patchesStrategicMerge:

--- a/examples/use-cases/SriovKernel2Noop/README.md
+++ b/examples/use-cases/SriovKernel2Noop/README.md
@@ -10,7 +10,7 @@ Make sure that you have completed steps from [sriov](../../sriov) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -24,9 +24,9 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel-ponger?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel-ponger?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 
 patchesStrategicMerge:

--- a/examples/use-cases/SriovKernel2Noop/README.md
+++ b/examples/use-cases/SriovKernel2Noop/README.md
@@ -10,7 +10,7 @@ Make sure that you have completed steps from [sriov](../../sriov) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -24,9 +24,9 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel-ponger?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-kernel?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-kernel-ponger?ref=v1.4.0
 
 
 patchesStrategicMerge:

--- a/examples/use-cases/Vfio2Noop/README.md
+++ b/examples/use-cases/Vfio2Noop/README.md
@@ -10,7 +10,7 @@ Make sure that you have completed steps from [sriov](../../sriov) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -61,8 +61,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=v1.4.0
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=aac4a0939f1fed428f99761b827e0ba2c876680b
 
 patchesStrategicMerge:
 - patch-nse-vfio.yaml

--- a/examples/use-cases/Vfio2Noop/README.md
+++ b/examples/use-cases/Vfio2Noop/README.md
@@ -10,7 +10,7 @@ Make sure that you have completed steps from [sriov](../../sriov) setup.
 
 Create test namespace:
 ```bash
-NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/examples/use-cases/namespace.yaml)[0])
+NAMESPACE=($(kubectl create -f https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/examples/use-cases/namespace.yaml)[0])
 NAMESPACE=${NAMESPACE:10}
 ```
 
@@ -61,8 +61,8 @@ kind: Kustomization
 namespace: ${NAMESPACE}
 
 bases:
-- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
-- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533
+- https://github.com/networkservicemesh/deployments-k8s/apps/nsc-vfio?ref=v1.4.0
+- https://github.com/networkservicemesh/deployments-k8s/apps/nse-vfio?ref=v1.4.0
 
 patchesStrategicMerge:
 - patch-nse-vfio.yaml

--- a/to-export.sh
+++ b/to-export.sh
@@ -21,7 +21,7 @@ grep 'raw.githubusercontent.com' -rl examples/* | while IFS= read -r file; do
   sedi -E "s/(https:\/\/)?raw.githubusercontent.com\/networkservicemesh\/deployments-k8s\/[a-z0-9.]*\/(.*)/${root}\2/g" "${file}"
 done
 
-grep '?ref=v1.4.0' -rl examples/* | while IFS= read -r file; do
+grep '?ref=aac4a0939f1fed428f99761b827e0ba2c876680b' -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
-  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=v1.4.0/${root}\2/g" "${file}"
+  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=aac4a0939f1fed428f99761b827e0ba2c876680b/${root}\2/g" "${file}"
 done

--- a/to-export.sh
+++ b/to-export.sh
@@ -21,7 +21,7 @@ grep 'raw.githubusercontent.com' -rl examples/* | while IFS= read -r file; do
   sedi -E "s/(https:\/\/)?raw.githubusercontent.com\/networkservicemesh\/deployments-k8s\/[a-z0-9.]*\/(.*)/${root}\2/g" "${file}"
 done
 
-grep '?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533' -rl examples/* | while IFS= read -r file; do
+grep '?ref=v1.4.0' -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
-  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533/${root}\2/g" "${file}"
+  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=v1.4.0/${root}\2/g" "${file}"
 done

--- a/to-local.sh
+++ b/to-local.sh
@@ -22,7 +22,7 @@ grep 'raw.githubusercontent.com' -rl examples/* | while IFS= read -r file; do
   sedi -E "s/(https:\/\/)?raw.githubusercontent.com\/networkservicemesh\/deployments-k8s\/[a-z0-9.]*\/(.*)/${root}\/\2/g" "${file}"
 done
 
-grep '?ref=v1.4.0' -rl examples/* | while IFS= read -r file; do
+grep '?ref=aac4a0939f1fed428f99761b827e0ba2c876680b' -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
-  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=v1.4.0/${root}\/\2/g" "${file}"
+  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=aac4a0939f1fed428f99761b827e0ba2c876680b/${root}\/\2/g" "${file}"
 done

--- a/to-local.sh
+++ b/to-local.sh
@@ -22,7 +22,7 @@ grep 'raw.githubusercontent.com' -rl examples/* | while IFS= read -r file; do
   sedi -E "s/(https:\/\/)?raw.githubusercontent.com\/networkservicemesh\/deployments-k8s\/[a-z0-9.]*\/(.*)/${root}\/\2/g" "${file}"
 done
 
-grep '?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533' -rl examples/* | while IFS= read -r file; do
+grep '?ref=v1.4.0' -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
-  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533/${root}\/\2/g" "${file}"
+  sedi -E "s/(https:\/\/)?github.com\/networkservicemesh\/deployments-k8s\/(.*)\?ref=v1.4.0/${root}\/\2/g" "${file}"
 done

--- a/to-ref.sh
+++ b/to-ref.sh
@@ -17,13 +17,13 @@ get_root() {
   escape "${root}"
 }
 
-FILE_PATTERN="$(escape 'https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/4c86db32f766d40e68e5a07ce1eca6b7f2442533/\1')"
+FILE_PATTERN="$(escape 'https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/\1')"
 grep "$(pwd)" -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
   sedi -E "s/${root//./\.}\/([^ ]*\.[a-z]+)/${FILE_PATTERN}/g" "${file}"
 done
 
-DIR_PATTERN="$(escape 'https://github.com/networkservicemesh/deployments-k8s/\1?ref=4c86db32f766d40e68e5a07ce1eca6b7f2442533')"
+DIR_PATTERN="$(escape 'https://github.com/networkservicemesh/deployments-k8s/\1?ref=v1.4.0')"
 grep "$(pwd)" -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
   sedi -E "s/${root//./\.}\/([^ ]*)/${DIR_PATTERN}/g" "${file}"

--- a/to-ref.sh
+++ b/to-ref.sh
@@ -17,13 +17,13 @@ get_root() {
   escape "${root}"
 }
 
-FILE_PATTERN="$(escape 'https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.4.0/\1')"
+FILE_PATTERN="$(escape 'https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/aac4a0939f1fed428f99761b827e0ba2c876680b/\1')"
 grep "$(pwd)" -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
   sedi -E "s/${root//./\.}\/([^ ]*\.[a-z]+)/${FILE_PATTERN}/g" "${file}"
 done
 
-DIR_PATTERN="$(escape 'https://github.com/networkservicemesh/deployments-k8s/\1?ref=v1.4.0')"
+DIR_PATTERN="$(escape 'https://github.com/networkservicemesh/deployments-k8s/\1?ref=aac4a0939f1fed428f99761b827e0ba2c876680b')"
 grep "$(pwd)" -rl examples/* | while IFS= read -r file; do
   root="$(get_root "$file")"
   sedi -E "s/${root//./\.}\/([^ ]*)/${DIR_PATTERN}/g" "${file}"


### PR DESCRIPTION
This is a workaround for [spiffe/spire#3032](https://github.com/spiffe/spire/issues/3032) to eliminate the occasional spire-agent restarts when the trust bundle file is not ready to be parsed.

An additional init container in spire-agent pod waits for the trust bundle to be in place.
It checks if the file exists or not, if it is not there the init sleeps a second and checks again.
It repeats 5 times before init container returns with completed status.
Usually, just to start a second init container is enough because during my previous measurements, trust bundle gets in place within 0.1 second. So, the 5 times repetition with 1 second sleep must be more than enough.

If there will be a solution at SPIRE side that handles the bundle config map in event-driven way then this workaround can be removed, but it does not make any harm if kept.