### PR TITLE
Workaround for spiffe/spire#2872

### DIFF
--- a/examples/spire/server-statefulset.yaml
+++ b/examples/spire/server-statefulset.yaml
@@ -47,6 +47,13 @@ spec:
           readinessProbe:
             exec:
               command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
+          # This is a workaround for https://github.com/spiffe/spire/issues/2872 
+          # that prevents k8s-workload-registrar container restarts until 
+          # https://github.com/spiffe/spire/pull/2921 will come with SPIRE 1.3.0.
+          lifecycle:
+            postStart:
+              exec:
+                command: ["sleep", "2"]
         - name: k8s-workload-registrar
           image: gcr.io/spiffe-io/k8s-workload-registrar:1.2.3
           args:

--- a/examples/spire/server-statefulset.yaml
+++ b/examples/spire/server-statefulset.yaml
@@ -47,8 +47,8 @@ spec:
           readinessProbe:
             exec:
               command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
-          # This is a workaround for https://github.com/spiffe/spire/issues/2872 
-          # that prevents k8s-workload-registrar container restarts until 
+          # This is a workaround for https://github.com/spiffe/spire/issues/2872
+          # that prevents k8s-workload-registrar container restarts until
           # https://github.com/spiffe/spire/pull/2921 will come with SPIRE 1.3.0.
           lifecycle:
             postStart:


### PR DESCRIPTION
This is a workaround for https://github.com/spiffe/spire/issues/2872 that prevents k8s-workload-registrar container restarts until https://github.com/spiffe/spire/pull/2921 will come with SPIRE 1.3.0. It does not cause any harm if this workaround remains even with SPIRE 1.3.0 or later.

Explanation:
As k8s-workload-registrar tries to connect to the spire's UDS server socket which is not ready yet.
It is handled as a hard fault by k8s-workload-registrar and it restarts.

There is a start sequence that kubelet composes from the spec.containers array, based on the order of the listed containers.
So, kubelet downloads spire-server image first then it immediately starts the container.
While workload-registrar's image is being downloaded. That is why we do not observe the restart on a fresh cluster.

There is a way how we can ensure there is order between the start of the containers in a pod.
I defined a postStart lifecycle statement in the spire-server container definition.
I put a simple sleep command with 2 seconds as parameter. It will cause that kubelet is waiting 2 seconds before starts the next container in the pod (k8s-workload-registrar).
It means spire-server will have two more seconds to be ready with its UDS server.
I tested it and worked fine in 100% of the cases.