### PR TITLE
Delete refcheck job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,36 +24,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: shellcheck
         uses: fkautz/shell-linter@v1.0.1
-  refcheck:
-    name: refcheck
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout default branch
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout PR branch
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Convert to local and back and check refs
-        run: |
-          ./to-local.sh
-          ./to-ref.sh
-
-          added_files=$(git diff --name-only --diff-filter=A --merge-base origin/main HEAD)
-
-          prefix="':!"
-          postfix="'"
-          exclude=""
-          for file in ${added_files}; do
-            exclude="${exclude} ${prefix}${file}${postfix}"
-          done
-
-          eval "git diff --exit-code --name-only -- . ${exclude}"
   image-check:
     name: Check that image is pullable
     runs-on: ubuntu-latest


### PR DESCRIPTION
Delete `refcheck` job because updating references happens after push to the main branch

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>