### PR TITLE
Fix vfio examples due to packet cluster api port

### DIFF
--- a/apps/nsc-kernel-ponger/ponger.yaml
+++ b/apps/nsc-kernel-ponger/ponger.yaml
@@ -20,7 +20,7 @@ spec:
         - name: ponger
           image: frolvlad/alpine-bash:latest
           imagePullPolicy: IfNotPresent
-          command: ["bin/bash", "root/scripts/pong.sh", "eno4", "172.16.1.100/32", "172.16.1.101/32"]
+          command: ["bin/bash", "root/scripts/pong.sh", "ens6f3", "172.16.1.100/32", "172.16.1.101/32"]
           securityContext:
             privileged: true
           volumeMounts:

--- a/apps/nsc-vfio/nsc.yaml
+++ b/apps/nsc-vfio/nsc.yaml
@@ -21,6 +21,10 @@ spec:
           image: artgl/dpdk-pingpong:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "-c", "sleep 60m"]
+          securityContext:
+            capabilities:
+              add:
+                - SYS_RESOURCE
           volumeMounts:
             - name: vfio
               mountPath: /dev/vfio
@@ -41,6 +45,8 @@ spec:
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_NETWORK_SERVICES
               value: vfio://pingpong?sriovToken=worker.domain/10G
+            - name: NSM_LIVENESSCHECKENABLED
+              value: "false"
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/nse-vfio/nse-configmap.yaml
+++ b/apps/nse-vfio/nse-configmap.yaml
@@ -54,6 +54,7 @@ data:
     bind_driver "${pci_addr}" "vfio-pci"
     test $? -eq 0 || exit 3
 
+    ulimit -l 65536
     # Run dpdk-pingpong (server)
     /root/dpdk-pingpong/build/app/pingpong \
       --no-huge \

--- a/apps/nse-vfio/nse.yaml
+++ b/apps/nse-vfio/nse.yaml
@@ -21,7 +21,7 @@ spec:
           # https://github.com/glazychev-art/docker-dpdk
           image: artgl/dpdk-pingpong:latest
           imagePullPolicy: IfNotPresent
-          command: ["/bin/bash", "/root/scripts/pong.sh", "eno4", "31", "0a:55:44:33:22:11"]
+          command: ["/bin/bash", "/root/scripts/pong.sh", "ens6f3", "31", "0a:55:44:33:22:11"]
           securityContext:
             privileged: true
           volumeMounts:

--- a/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Kernel&Vfio2Noop/README.md
@@ -110,7 +110,7 @@ spec:
             - name: NSM_SERVICES
               value: "pingpong@worker.domain: { addr: ${SERVER_MAC} }"
         - name: ponger
-          command: ["/bin/bash", "/root/scripts/pong.sh", "eno4", "31", ${SERVER_MAC}]
+          command: ["/bin/bash", "/root/scripts/pong.sh", "ens6f3", "31", ${SERVER_MAC}]
 EOF
 ```
 
@@ -153,7 +153,7 @@ function dpdk_ping() {
   client_mac="$1"
   server_mac="$2"
 
-  command="/root/dpdk-pingpong/build/app/pingpong \
+  command="ulimit -l 65536 && /root/dpdk-pingpong/build/app/pingpong \
       --no-huge                                   \
       --                                          \
       -n 500                                      \
@@ -209,7 +209,7 @@ NSE_VFIO=$(kubectl get pods -l app=nse-vfio -n ${NAMESPACE} --template '{{range 
 ```
 ```bash
 kubectl -n ${NAMESPACE} exec ${NSE_VFIO} --container ponger -- /bin/bash -c '\
-  sleep 10 && kill $(pgrep "pingpong") 1>/dev/null 2>&1 &                    \
+  (sleep 10 && kill $(pgrep "pingpong")) 1>/dev/null 2>&1 &                  \
 '
 ```
 

--- a/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Vxlan2Kernel&Vfio2Noop/README.md
@@ -110,7 +110,7 @@ spec:
             - name: NSM_SERVICES
               value: "pingpong@worker.domain: { addr: ${SERVER_MAC} }"
         - name: ponger
-          command: ["/bin/bash", "/root/scripts/pong.sh", "eno4", "31", ${SERVER_MAC}]
+          command: ["/bin/bash", "/root/scripts/pong.sh", "ens6f3", "31", ${SERVER_MAC}]
 EOF
 ```
 
@@ -153,7 +153,7 @@ function dpdk_ping() {
   client_mac="$1"
   server_mac="$2"
 
-  command="/root/dpdk-pingpong/build/app/pingpong \
+  command="ulimit -l 65536 && /root/dpdk-pingpong/build/app/pingpong \
       --no-huge                                   \
       --                                          \
       -n 500                                      \
@@ -209,7 +209,7 @@ NSE_VFIO=$(kubectl get pods -l app=nse-vfio -n ${NAMESPACE} --template '{{range 
 ```
 ```bash
 kubectl -n ${NAMESPACE} exec ${NSE_VFIO} --container ponger -- /bin/bash -c '\
-  sleep 10 && kill $(pgrep "pingpong") 1>/dev/null 2>&1 &                    \
+  (sleep 10 && kill $(pgrep "pingpong")) 1>/dev/null 2>&1 &                  \
 '
 ```
 

--- a/examples/use-cases/Vfio2Noop/README.md
+++ b/examples/use-cases/Vfio2Noop/README.md
@@ -47,7 +47,7 @@ spec:
             - name: NSM_SERVICES
               value: "pingpong@worker.domain: { addr: ${SERVER_MAC} }"
         - name: ponger
-          command: ["/bin/bash", "/root/scripts/pong.sh", "eno4", "31", ${SERVER_MAC}]
+          command: ["/bin/bash", "/root/scripts/pong.sh", "ens6f3", "31", ${SERVER_MAC}]
 EOF
 ```
 
@@ -96,7 +96,7 @@ function dpdk_ping() {
   client_mac="$1"
   server_mac="$2"
 
-  command="/root/dpdk-pingpong/build/app/pingpong \
+  command="ulimit -l 65536 && /root/dpdk-pingpong/build/app/pingpong \
       --no-huge                                   \
       --                                          \
       -n 500                                      \
@@ -140,7 +140,7 @@ NSE=$(kubectl -n ${NAMESPACE} get pods -l app=nse-vfio --template '{{range .item
 ```
 ```bash
 kubectl -n ${NAMESPACE} exec ${NSE} --container ponger -- /bin/bash -c '\
-  sleep 10 && kill $(pgrep "pingpong") 1>/dev/null 2>&1 &               \
+  (sleep 10 && kill $(pgrep "pingpong")) 1>/dev/null 2>&1 &             \
 '
 ```
 


### PR DESCRIPTION
### Description:
Issue: https://github.com/networkservicemesh/integration-k8s-packet/issues/295

Main changes:
1. `n3-xlarge` has other interface names (eno4 -> ens6f3)
2. Packet cluster API uses `containerd` instead of `docker` as a container runtime. `containerd` hasn't default limits. We need to set it manually using `ulimit`(required for SRIOV tests)

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>