### PR TITLE
Handle Azure VM reverse DNS zone

### DIFF
--- a/examples/floating_interdomain/dns/README.md
+++ b/examples/floating_interdomain/dns/README.md
@@ -155,6 +155,11 @@ data:
         loop
         reload 5s
     }
+    # Azure reverse DNS zone
+    internal.cloudapp.net:53 {
+      errors
+      forward . 168.63.129.16
+    }
     my.cluster2:53 {
       forward . ${ip2}:53 {
         force_tcp
@@ -241,6 +246,11 @@ data:
         loop
         reload 5s
     }
+    # Azure reverse DNS zone
+    internal.cloudapp.net:53 {
+      errors
+      forward . 168.63.129.16
+    }
     my.cluster1:53 {
       forward . ${ip1}:53 {
         force_tcp
@@ -326,6 +336,11 @@ data:
         }
         loop
         reload 5s
+    }
+    # Azure reverse DNS zone
+    internal.cloudapp.net:53 {
+      errors
+      forward . 168.63.129.16
     }
     my.cluster1:53 {
       forward . ${ip1}:53 {

--- a/examples/interdomain/dns/README.md
+++ b/examples/interdomain/dns/README.md
@@ -72,6 +72,11 @@ data:
         loop
         reload 5s
     }
+    # Azure reverse DNS zone
+    internal.cloudapp.net:53 {
+      errors
+      forward . 168.63.129.16
+    }
     my.cluster2:53 {
       forward . ${ip2}:53 {
         force_tcp
@@ -127,6 +132,11 @@ data:
         }
         loop
         reload 5s
+    }
+    # Azure reverse DNS zone
+    internal.cloudapp.net:53 {
+      errors
+      forward . 168.63.129.16
     }
     my.cluster1:53 {
       forward . ${ip1}:53 {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Azure VM uses **internal.cloudapp.net** for reverse DNS. 
And this DNS server is available on 168.63.129.16.

This PR directly adds this zone to coredns config. Otherwise, IPv6 resolution takes a very long time (more than 5 seconds).

Links:
https://github.com/uglide/azure-content/blob/master/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
https://www.digihunch.com/2021/12/aks-lessons-learned-2-of-2/

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
