### PR TITLE
qfix: replace GITHUB_TOKEN with NSM_BOT_GITHUB_TOKEN for automerge

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           GITHUB_LOGIN: nsmbot
           ENABLED_FOR_MANUAL_CHANGES: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
           MAXIMUM_RETRIES: 25
 
   delete-release-branch:


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
