### PR TITLE
dns test: send A and AAAA DNS requests

### DIFF
--- a/examples/features/dns/README.md
+++ b/examples/features/dns/README.md
@@ -45,7 +45,7 @@ kubectl exec ${NSC} -c dnsutils -n ns-dns -- ping -c 4 my.coredns.service
 
 Validate that default DNS server is working:
 ```bash
-kubectl exec ${NSC} -c dnsutils -n ns-dns -- nslookup kubernetes.default
+kubectl exec ${NSC} -c dnsutils -n ns-dns -- dig kubernetes.default A kubernetes.default AAAA | grep "kubernetes.default.svc.cluster.local"
 ```
 
 ## Cleanup


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
`nslookup` and `dig` use A question type by default.
Added A and AAAA requests.


## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/738
https://github.com/networkservicemesh/integration-k8s-aws/issues/324


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
