### PR TITLE
nsmgr: use specific IP for public address

### DIFF
--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -41,7 +41,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: NSM_LISTEN_ON
-              value: unix:///var/lib/networkservicemesh/nsm.io.sock,tcp://:5001
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock,tcp://[$(POD_IP)]:5001
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -63,7 +63,7 @@ spec:
               cpu: 400m
           readinessProbe:
             exec:
-              command: ["/bin/grpc-health-probe", "-spiffe", "-addr=:5001"]
+              command: ["/bin/grpc-health-probe", "-spiffe", "-addr=unix:///var/lib/networkservicemesh/nsm.io.sock"]
             failureThreshold: 120
             initialDelaySeconds: 1
             periodSeconds: 1
@@ -71,14 +71,14 @@ spec:
             timeoutSeconds: 2
           livenessProbe:
             exec:
-              command: ["/bin/grpc-health-probe", "-spiffe", "-addr=:5001"]
+              command: ["/bin/grpc-health-probe", "-spiffe", "-addr=unix:///var/lib/networkservicemesh/nsm.io.sock"]
             failureThreshold: 25
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 2
           startupProbe:
             exec:
-              command: ["/bin/grpc-health-probe", "-spiffe", "-addr=:5001"]
+              command: ["/bin/grpc-health-probe", "-spiffe", "-addr=unix:///var/lib/networkservicemesh/nsm.io.sock"]
             failureThreshold: 25
             periodSeconds: 5
         - image: ghcr.io/networkservicemesh/ci/cmd-exclude-prefixes-k8s:4153e91


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
`tcp://:5001` is used to automatically resolve public IP address.
But Pod may have predefined interfaces with any address. For example, there are 2 interfaces with IPv4 (predefined) and IPv6 (Pod interface). We are interested in IPv6, but IPv4 was automatically selected, and this is not correct.

We need to explicitly specify the Pod IP address

**_Note_**: brackets `[...]` work correctly for both IPv6 and IPv4


## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/738
https://github.com/networkservicemesh/integration-k8s-aws/issues/324


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
