### PR TITLE
heal: handle "Network unreachable" error

### DIFF
--- a/examples/heal/local-nse-death/README.md
+++ b/examples/heal/local-nse-death/README.md
@@ -52,7 +52,7 @@ kubectl scale deployment nse-kernel -n ns-local-nse-death --replicas=0
 ```
 
 ```bash
-kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.100 | grep "100% packet loss"
+kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.100 2>&1 | egrep "100% packet loss|Network unreachable"
 ```
 
 Apply patch:


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
After deleting an endpoint, we can also get "Network unreachable" error.  We can get this when we don't have any IPv4 routes.
For example, this is possible if we have an ipv6 cluster and the pod doesn't have ipv4 addresses (and routes)


## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/738
https://github.com/networkservicemesh/integration-k8s-aws/issues/324


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
