### PR TITLE
Add MTU adjustment checks in remote VLAN examples

### DIFF
--- a/examples/remotevlan/README.md
+++ b/examples/remotevlan/README.md
@@ -30,9 +30,11 @@ ifw2=$(docker exec kind-worker2 ip -o link | grep ${MACS[@]/#/-e } | cut -f1 -d"
 
 (docker exec kind-worker ip link set $ifw1 down &&
 docker exec kind-worker ip link set $ifw1 name ext_net1 &&
+docker exec kind-worker ip link set dev ext_net1 mtu 1450 &&
 docker exec kind-worker ip link set ext_net1 up &&
 docker exec kind-worker2 ip link set $ifw2 down &&
 docker exec kind-worker2 ip link set $ifw2 name ext_net1 &&
+docker exec kind-worker2 ip link set dev ext_net1 mtu 1450 &&
 docker exec kind-worker2 ip link set ext_net1 up)
 ```
 

--- a/examples/use-cases/Kernel2RVlanMultiNS/README.md
+++ b/examples/use-cases/Kernel2RVlanMultiNS/README.md
@@ -358,6 +358,32 @@ Get the NSC pods from first k8s namespace:
 NSCS=($(kubectl get pods -l app=alpine-1 -n ns-kernel2vlan-multins-1 --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'))
 ```
 
+Check the MTU adjustment for the NSC pods from first k8s namespace::
+
+```bash
+status=0
+LINK_MTU=$(docker exec kind-worker cat /sys/class/net/ext_net1/mtu)
+for nsc in "${NSCS[@]}"
+do
+  MTU=$(kubectl exec ${nsc} -c cmd-nsc -n ns-kernel2vlan-multins-1 -- cat /sys/class/net/nsm-1/mtu)
+
+  echo "$LINK_MTU vs $MTU"
+
+  if test "${MTU}" = ""
+    then
+      status=1
+  fi
+  if test $MTU -ne $LINK_MTU
+    then
+      status=2
+  fi
+done
+if test ${status} -ne 0
+  then
+    false
+fi
+```
+
 Get the IP addresses for NSCs from first k8s namespace:
 
 ```bash
@@ -399,6 +425,31 @@ Get the NSC pods from second k8s namespace:
 ```bash
 NSCS_BLUE=($(kubectl get pods -l app=alpine-2 -n ns-kernel2vlan-multins-2 --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'))
 NSCS_GREEN=($(kubectl get pods -l app=alpine-3 -n ns-kernel2vlan-multins-2 --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'))
+```
+
+Check the MTU adjustment for the NSC pods from second k8s namespace::
+
+```bash
+status=0
+for nsc in "${NSCS_BLUE[@]} ${NSCS_GREEN[@]}"
+do
+  MTU=$(kubectl exec ${nsc} -c cmd-nsc -n ns-kernel2vlan-multins-2 -- cat /sys/class/net/nsm-1/mtu)
+
+  echo "$LINK_MTU vs $MTU"
+
+  if test "${MTU}" = ""
+    then
+      status=1
+  fi
+  if test $MTU -ne $LINK_MTU
+    then
+      status=2
+  fi
+done
+if test ${status} -ne 0
+  then
+    false
+fi
 ```
 
 Get the IP addresses for NSCs from second k8s namespace:
@@ -462,6 +513,31 @@ Get the NSC pods from nsm-system k8s namespace:
 
 ```bash
 NSCS=($(kubectl get pods -l app=alpine-4 -n nsm-system --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'))
+```
+
+Check the MTU adjustment for the NSC pods from nsm-system k8s namespace::
+
+```bash
+status=0
+for nsc in "${NSCS[@]}"
+do
+  MTU=$(kubectl exec ${nsc} -c cmd-nsc -n nsm-system -- cat /sys/class/net/nsm-1/mtu)
+
+  echo "$LINK_MTU vs $MTU"
+
+  if test "${MTU}" = ""
+    then
+      status=1
+  fi
+  if test $MTU -ne $LINK_MTU
+    then
+      status=2
+  fi
+done
+if test ${status} -ne 0
+  then
+    false
+fi
 ```
 
 Get the IP addresses for NSCs from first k8s namespace:


### PR DESCRIPTION
Signed-off-by: Laszlo Kiraly <laszlo.kiraly@est.tech>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

The MTU value of the interface in NSC can not be bigger than the MTU value set on base interface

## Issue link

#7738 

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
