### PR TITLE
Add ping source address to heal tests

### DIFF
--- a/examples/heal/dataplane-interrupt/README.md
+++ b/examples/heal/dataplane-interrupt/README.md
@@ -38,12 +38,12 @@ NSE=$(kubectl get pods -l app=nse-kernel -n ns-dataplane-interrupt --template '{
 
 Ping from NSC to NSE:
 ```bash
-kubectl exec ${NSC} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.100
+kubectl exec ${NSC} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.100 -I 172.16.1.101
 ```
 
 Ping from NSE to NSC:
 ```bash
-kubectl exec ${NSE} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.101
+kubectl exec ${NSE} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.101 -I 172.16.1.100
 ```
 
 Run a pinger process in the background. The pinger will run until it encounters missing packets.
@@ -52,7 +52,7 @@ PINGER_PATH=/tmp/done-${RANDOM}
 kubectl exec ${NSC} -n ns-dataplane-interrupt -- sh -c '
   PINGER_PATH=$1; rm -f "$PINGER_PATH"
   seq=0
-  ping -i 0.2 172.16.1.100 | while :; do
+  ping -i 0.2 172.16.1.100 -I 172.16.1.101 | while :; do
     read -t 1 line || { echo ping timeout; touch $PINGER_PATH; break; }
     seq1=$(echo $line | sed -n "s/.* seq=\([0-9]\+\) .*/\1/p")
     [ "$seq1" ] || continue
@@ -76,12 +76,12 @@ kubectl exec ${NSC} -n ns-dataplane-interrupt -- sh -c 'timeout 10 sh -c "while 
 
 Ping from NSC to NSE:
 ```bash
-kubectl exec ${NSC} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.100
+kubectl exec ${NSC} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.100 -I 172.16.1.101
 ```
 
 Ping from NSE to NSC:
 ```bash
-kubectl exec ${NSE} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.101
+kubectl exec ${NSE} -n ns-dataplane-interrupt -- ping -c 4 172.16.1.101 -I 172.16.1.100
 ```
 
 ## Cleanup

--- a/examples/heal/local-nse-death/README.md
+++ b/examples/heal/local-nse-death/README.md
@@ -38,12 +38,12 @@ NSE=$(kubectl get pods -l app=nse-kernel -n ns-local-nse-death --template '{{ran
 
 Ping from NSC to NSE:
 ```bash
-kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.100
+kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.100 -I 172.16.1.101
 ```
 
 Ping from NSE to NSC:
 ```bash
-kubectl exec ${NSE} -n ns-local-nse-death -- ping -c 4 172.16.1.101
+kubectl exec ${NSE} -n ns-local-nse-death -- ping -c 4 172.16.1.101 -I 172.16.1.100
 ```
 
 Stop NSE pod:
@@ -52,7 +52,7 @@ kubectl scale deployment nse-kernel -n ns-local-nse-death --replicas=0
 ```
 
 ```bash
-kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.100 2>&1 | egrep "100% packet loss|Network unreachable"
+kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.100 -I 172.16.1.101 2>&1 | egrep "100% packet loss|Network unreachable|can't set multicast source"
 ```
 
 Apply patch:
@@ -80,12 +80,12 @@ Ping should pass with newly configured addresses.
 
 Ping from NSC to new NSE:
 ```bash
-kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.102
+kubectl exec ${NSC} -n ns-local-nse-death -- ping -c 4 172.16.1.102 -I 172.16.1.103
 ```
 
 Ping from new NSE to NSC:
 ```bash
-kubectl exec ${NEW_NSE} -n ns-local-nse-death -- ping -c 4 172.16.1.103
+kubectl exec ${NEW_NSE} -n ns-local-nse-death -- ping -c 4 172.16.1.103 -I 172.16.1.102
 ```
 
 ## Cleanup


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This PR adds ping source address to some heal tests. This is necessary to be sure that the ping comes from the nsm interface.


## Issue link
https://github.com/networkservicemesh/integration-k8s-packet/issues/306


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
