### PR TITLE
Replace "go get" with "go install"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,9 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
       - name: Setup envs
         run: |
           echo GOPATH=$GITHUB_WORKSPACE >> $GITHUB_ENV
@@ -114,10 +117,12 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
           ref: release/${{ needs.create-release.outputs.tag }}
       - name: Install gotestmd
-        run: "go get github.com/networkservicemesh/gotestmd"
+        run: |
+          go install github.com/networkservicemesh/gotestmd@main
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Install goimports
-        run: "go get golang.org/x/tools/cmd/goimports"
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/update-dependent-repositories.yaml
+++ b/.github/workflows/update-dependent-repositories.yaml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
       - name: Setup envs
         run: |
           echo GOPATH=$GITHUB_WORKSPACE >> $GITHUB_ENV
@@ -29,10 +32,12 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
           fetch-depth: 2
       - name: Install gotestmd
-        run: "go get github.com/networkservicemesh/gotestmd"
+        run: |
+          go install github.com/networkservicemesh/gotestmd@main
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Install goimports
-        run: "go get golang.org/x/tools/cmd/goimports"
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Get hash of PR commit
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
@@ -51,9 +56,6 @@ jobs:
           path: ${{ github.workspace }}/src/github.com/networkservicemesh/${{ matrix.repository }}
           repository: networkservicemesh/${{ matrix.repository }}
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
-      - uses: actions/setup-go@v1
-        with:
-          go-version: 1.18
       - name: Update ${{ matrix.repository }} locally
         working-directory: ${{ github.workspace }}/src/github.com/networkservicemesh/${{ matrix.repository }}
         run: |


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Since go 1.17 `go get` is deprecated - https://go.dev/doc/go-get-install-deprecation


## Issue link
https://github.com/networkservicemesh/deployments-k8s/actions/runs/3527766888/jobs/5917182809


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
