### PR TITLE
qfix: Replace 'REGISTRY_K8S' to 'NSM' since registry-k8s env prefix updated

### DIFF
--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -21,15 +21,15 @@ spec:
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
-            - name: REGISTRY_K8S_NAMESPACE
+            - name: NSM_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: REGISTRY_K8S_LOG_LEVEL
+            - name: NSM_LOG_LEVEL
               value: TRACE
-            - name: REGISTRY_K8S_LISTEN_ON
+            - name: NSM_LISTEN_ON
               value: tcp://:5002
-            - name: REGISTRY_K8S_PROXY_REGISTRY_URL
+            - name: NSM_PROXY_REGISTRY_URL
               value: nsmgr-proxy:5004
           imagePullPolicy: IfNotPresent
           name: registry


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>



## Issue link
Related to 

https://github.com/networkservicemesh/deployments-k8s/issues/8187
https://github.com/networkservicemesh/cmd-registry-k8s/pull/360

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [X] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [X] Refactoring
- [ ] CI
