### PR TITLE
Add POD_NAME env to vl3-nse to be able to resolve the NSE name by DNS

### DIFF
--- a/apps/nse-vl3-vpp/nse.yaml
+++ b/apps/nse-vl3-vpp/nse.yaml
@@ -28,6 +28,10 @@ spec:
                   fieldPath: metadata.name
             - name: NSM_LOG_LEVEL
               value: TRACE
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/examples/features/vl3-dns/README.md
+++ b/examples/features/vl3-dns/README.md
@@ -54,6 +54,25 @@ done
 )
 ```
 
+Find vl3-nses:
+```bash
+nses=$(kubectl get pods -l app=nse-vl3-vpp -o go-template --template="{{range .items}}{{.metadata.name}} {{end}}" -n ns-vl3-dns)
+[[ ! -z nses ]]
+```
+
+Ping each vl3-nse by each client via DNS:
+```bash
+(
+for nse in $nses
+do
+    for pinger in $nscs
+    do
+        kubectl exec $pinger -n ns-vl3-dns -- ping -c2 -i 0.5 $nse.vl3-dns -4 || exit
+    done
+done
+)
+```
+
 ## Cleanup
 
 To cleanup the example just follow the next command:

--- a/examples/features/vl3-scale-from-zero/pod-template.yaml
+++ b/examples/features/vl3-scale-from-zero/pod-template.yaml
@@ -30,6 +30,10 @@ spec:
           value: 15s
         - name: NSM_LABELS
           value: app:nse-vl3-vpp
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumeMounts:
         - name: spire-agent-socket
           mountPath: /run/spire/sockets

--- a/examples/interdomain/nsm_consul_vl3/cluster1/nse-vl3-vpp/nse.yaml
+++ b/examples/interdomain/nsm_consul_vl3/cluster1/nse-vl3-vpp/nse.yaml
@@ -28,6 +28,10 @@ spec:
                   fieldPath: metadata.name
             - name: NSM_LOG_LEVEL
               value: TRACE
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster1/nse-vl3-vpp.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster1/nse-vl3-vpp.yaml
@@ -26,6 +26,10 @@ spec:
           value: "tcp://vl3-ipam.nsm-system.my.cluster3:5006"
         - name: NSM_LOG_LEVEL
           value: TRACE
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumeMounts:
         - name: spire-agent-socket
           mountPath: /run/spire/sockets

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster2/nse-vl3-vpp.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster2/nse-vl3-vpp.yaml
@@ -26,6 +26,10 @@ spec:
           value: "tcp://vl3-ipam.nsm-system.my.cluster3:5006"
         - name: NSM_LOG_LEVEL
           value: TRACE
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumeMounts:
         - name: spire-agent-socket
           mountPath: /run/spire/sockets

--- a/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster1/pod-template.yaml
+++ b/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster1/pod-template.yaml
@@ -32,6 +32,10 @@ spec:
           value: 15s
         - name: NSM_LOG_LEVEL
           value: TRACE
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumeMounts:
         - name: spire-agent-socket
           mountPath: /run/spire/sockets

--- a/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster2/pod-template.yaml
+++ b/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster2/pod-template.yaml
@@ -32,6 +32,10 @@ spec:
           value: 15s
         - name: NSM_LOG_LEVEL
           value: TRACE
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumeMounts:
         - name: spire-agent-socket
           mountPath: /run/spire/sockets


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
If we add `POD_NAME` env to vl3-NSE we will be able to resolve endpoint DNS name


## Issue link
https://github.com/networkservicemesh/sdk/issues/1414


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
