### PR TITLE
Add vl3-nses ready wait

### DIFF
--- a/examples/heal/vl3-nse-death/README.md
+++ b/examples/heal/vl3-nse-death/README.md
@@ -15,6 +15,11 @@ Wait for clients to be ready:
 kubectl wait -n ns-vl3-nse-death --for=condition=ready --timeout=1m pod -l app=alpine
 ```
 
+Wait for vl3-nses to be ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nse-vl3-vpp -n ns-vl3-nse-death
+```
+
 Find all nscs:
 ```bash
 nscs=$(kubectl  get pods -l app=alpine -o go-template --template="{{range .items}}{{.metadata.name}} {{end}}" -n ns-vl3-nse-death) 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This PR will allow us to see which vl3-NSEs were before death

## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/776


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
