### PR TITLE
Temporarily disable livenesscheck for SriovKernel2Noop

### DIFF
--- a/examples/use-cases/SriovKernel2Noop/patch-nsc.yaml
+++ b/examples/use-cases/SriovKernel2Noop/patch-nsc.yaml
@@ -11,6 +11,8 @@ spec:
           env:
             - name: NSM_NETWORK_SERVICES
               value: kernel://sriov-kernel2noop/nsm-1?sriovToken=worker.domain/10G
+            - name: NSM_LIVENESSCHECKENABLED
+              value: "false"
           resources:
             limits:
               worker.domain/10G: 1


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
For some reason, datapath connection between servers is not established for a long time. Because of this, the checker makes Closes/Requests endlessly.
Temporarily disable to look at the stability.


## Issue link
https://github.com/networkservicemesh/integration-k8s-packet/pull/318


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
