### PR TITLE
Add interdomain DNS examples

### DIFF
--- a/examples/multicluster/README.md
+++ b/examples/multicluster/README.md
@@ -31,7 +31,7 @@ Interdomain tests can be on two clusters, for thus tests scheme of request will 
 - [Floating DNS](./usecases/floating_dns)
 - [Floating VL3](./usecases/floating_vl3-basic)
 - [Floating VL3_scale_from_zero](./usecases/floating_vl3-scale-from-zero)
-- [Floating VL3_DNS](./usecases/floating_vl3-dns)
+- [Floating VL3 DNS](./usecases/floating_vl3-dns)
 
 ## Run
 

--- a/examples/multicluster/README.md
+++ b/examples/multicluster/README.md
@@ -27,8 +27,11 @@ Interdomain tests can be on two clusters, for thus tests scheme of request will 
 - [Kernel to VXLAN to Kernel Connection via floating registry](./usecases/floating_Kernel2Vxlan2Kernel)
 - [Kernel to WIREGUARD to Kernel Connection](./usecases/interdomain_Kernel2Wireguard2Kernel)
 - [Kernel to WIREGUARD to Kernel Connection via floating registry](./usecases/floating_Kernel2Wireguard2Kernel)
+- [DNS](./usecases/interdomain_dns)
+- [Floating DNS](./usecases/floating_dns)
 - [Floating VL3](./usecases/floating_vl3-basic)
 - [Floating VL3_scale_from_zero](./usecases/floating_vl3-scale-from-zero)
+- [Floating VL3_DNS](./usecases/floating_vl3-dns)
 
 ## Run
 

--- a/examples/multicluster/dns/README.md
+++ b/examples/multicluster/dns/README.md
@@ -83,7 +83,7 @@ fi
 # if IPv6
 if [[ $ip2 =~ ":" ]]; then ip2=[$ip2]; fi
 
-echo Selected externalIP: $ip2 for cluster1
+echo Selected externalIP: $ip2 for cluster2
 [[ ! -z $ip2 ]]
 ```
 
@@ -114,7 +114,7 @@ fi
 # if IPv6
 if [[ $ip3 =~ ":" ]]; then ip3=[$ip3]; fi
 
-echo Selected externalIP: $ip3 for cluster1
+echo Selected externalIP: $ip3 for cluster3
 [[ ! -z $ip3 ]]
 ```
 

--- a/examples/multicluster/usecases/floating_dns/README.md
+++ b/examples/multicluster/usecases/floating_dns/README.md
@@ -1,0 +1,83 @@
+# Floating interdomain DNS example
+
+This example shows how DNS works for the client if the dns server (NSE) is located on another cluster.
+The NSE is registered in the floating registry.
+Note: NSE provides DNS by itself. Also, NSE could provide configs for any other external DNS servers(that are not located as sidecar with NSE).
+
+## Requires
+
+Make sure that you have completed steps from [multicluster](../../)
+
+## Run
+
+**1. Deploy network service on cluster3**
+
+Deploy NetworkService:
+```bash
+kubectl --kubeconfig=$KUBECONFIG3 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_dns/cluster3?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+**2. Deploy endpoint on cluster2**
+
+Deploy NSE:
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_dns/cluster2?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+Find NSE pod by labels:
+```bash
+NSE=$(kubectl --kubeconfig=$KUBECONFIG2 get pods -l app=nse-kernel -n ns-floating-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+[[ ! -z $NSE ]]
+```
+
+**3. Deploy client on cluster1**
+
+Deploy client:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_dns/cluster1?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+Wait for applications ready:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 wait --for=condition=ready --timeout=5m pod -l app=dnsutils -n ns-floating-dns
+```
+
+Find client pod by labels:
+```bash
+NSC=$(kubectl --kubeconfig=$KUBECONFIG1 get pods -l app=dnsutils -n ns-floating-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+[[ ! -z $NSC ]]
+```
+
+**4. Check connectivity**
+
+Find dns server using nslookup: 
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec ${NSC} -c dnsutils -n ns-floating-dns -- nslookup -norec -nodef my.coredns.service
+```
+
+Ping from dnsutils to NSE by domain name:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec ${NSC} -c dnsutils -n ns-floating-dns -- ping -c 4 my.coredns.service
+```
+
+Validate that the default DNS server is working:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec ${NSC} -c dnsutils -n ns-floating-dns -- dig kubernetes.default A kubernetes.default AAAA | grep "kubernetes.default.svc.cluster.local"
+```
+
+## Cleanup
+
+1. Cleanup resources for *cluster1*:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 delete ns ns-floating-dns
+```
+
+2. Cleanup resources for *cluster2*:
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 delete ns ns-floating-dns
+```
+
+3. Cleanup resources for *cluster3*:
+```bash
+kubectl --kubeconfig=$KUBECONFIG3 delete ns ns-floating-dns
+```

--- a/examples/multicluster/usecases/floating_dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster1/client.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dnsutils
+  labels:
+    app: dnsutils
+  annotations:
+    networkservicemesh.io: kernel://floating-dns@my.cluster3/nsm-1
+spec:
+  containers:
+    - name: dnsutils
+      image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
+      imagePullPolicy: IfNotPresent
+      stdin: true
+      tty: true

--- a/examples/multicluster/usecases/floating_dns/cluster1/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster1/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-floating-dns
+
+resources:
+- namespace.yaml
+- client.yaml

--- a/examples/multicluster/usecases/floating_dns/cluster1/namespace.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster1/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-dns

--- a/examples/multicluster/usecases/floating_dns/cluster2/coredns-config-map.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster2/coredns-config-map.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+data:
+  Corefile: |
+    . {
+        log
+        hosts {
+            no_recursive
+            172.16.1.2 my.coredns.service.
+        }
+    }

--- a/examples/multicluster/usecases/floating_dns/cluster2/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster2/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-floating-dns
+
+resources:
+- namespace.yaml
+- coredns-config-map.yaml
+- ../../../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nse.yaml

--- a/examples/multicluster/usecases/floating_dns/cluster2/namespace.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster2/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-dns

--- a/examples/multicluster/usecases/floating_dns/cluster2/patch-nse.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster2/patch-nse.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_NAME
+              value: "$(POD_NAME)@my.cluster3"
+            - name: NSM_CIDR_PREFIX
+              value: 172.16.1.2/31
+            - name: NSM_SERVICE_NAMES
+              value: "floating-dns"
+            - name: NSM_DNS_CONFIGS
+              value: "[{\"dns_server_ips\": [\"172.16.1.2\"], \"search_domains\": [\"my.coredns.service\"]}]"
+        - name: coredns
+          image: coredns/coredns:1.8.3
+          imagePullPolicy: IfNotPresent
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+              readOnly: true
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+              - key: Corefile
+                path: Corefile

--- a/examples/multicluster/usecases/floating_dns/cluster3/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster3/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-floating-dns
+
+resources:
+- namespace.yaml
+- netsvc.yaml

--- a/examples/multicluster/usecases/floating_dns/cluster3/namespace.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster3/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-dns

--- a/examples/multicluster/usecases/floating_dns/cluster3/netsvc.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster3/netsvc.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: networkservicemesh.io/v1
+kind: NetworkService
+metadata:
+  name: floating-dns
+spec:
+  payload: ETHERNET

--- a/examples/multicluster/usecases/floating_vl3-basic/README.md
+++ b/examples/multicluster/usecases/floating_vl3-basic/README.md
@@ -52,7 +52,7 @@ kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/
 export KUBECONFIG=$KUBECONFIG1
 ```
 
-1.4. Prepare a patch with **vl3 ipam URL**:
+1.4. Deploy a vl3-NSE and a client on the cluster1:
 
 ```bash
 kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-basic/cluster1?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
@@ -64,7 +64,7 @@ kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/
 export KUBECONFIG=$KUBECONFIG2
 ```
 
-1.7. Prepare a patch with **vl3 ipam URL**:
+1.6. Deploy a vl3-NSE and a client on the cluster2:
 
 ```bash
 kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-basic/cluster2?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster1/nse-vl3-vpp.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster1/nse-vl3-vpp.yaml
@@ -23,7 +23,7 @@ spec:
         - name: NSM_SERVICE_NAMES
           value: "my-interdomain-vl3-network@my.cluster3"
         - name: NSM_PREFIX_SERVER_URL
-          value: "tcp://vl3-ipam.nsm-system.my.cluster3:5006"
+          value: "tcp://vl3-ipam.ns-floating-vl3-basic.my.cluster3:5006"
         - name: NSM_LOG_LEVEL
           value: TRACE
         - name: POD_NAME

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster3/namespace.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster3/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-vl3-basic

--- a/examples/multicluster/usecases/floating_vl3-dns/README.md
+++ b/examples/multicluster/usecases/floating_vl3-dns/README.md
@@ -1,0 +1,101 @@
+# Floating VL3 DNS example
+
+## Description
+
+This example show how DNS works over VL3 network.
+
+## Requires
+
+Make sure that you have completed steps from [multicluster](../../)
+
+## Run
+
+**1. Deploy**
+
+1.1. Start **vl3 ipam** and register **vl3 network service** in the *floating domain*.
+Note: *By default ipam prefix is `172.16.0.0/16` and client prefix len is `24`. We also have two vl3 nses in this example. So we expect to have two vl3 addresses: `172.16.0.0` and `172.16.1.0` that should be accessible by each client.*
+
+```bash
+kubectl --kubeconfig=$KUBECONFIG3 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-dns/cluster3?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+1.2. Deploy a vl3-NSE and a client on the cluster1:
+
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-dns/cluster1?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 wait --for=condition=ready --timeout=5m pod -l app=alpine -n ns-floating-vl3-dns
+```
+
+1.3. Deploy a vl3-NSE and a client on the cluster2:
+
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-dns/cluster2?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 wait --for=condition=ready --timeout=5m pod -l app=alpine -n ns-floating-vl3-dns
+```
+
+**2. Get assigned endpoint names**
+
+2.1. Find NSC and NSE in the *cluster1*:
+
+```bash
+nsc1=$(kubectl --kubeconfig=$KUBECONFIG1 get pods -l app=alpine -n ns-floating-vl3-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+nse1=$(kubectl --kubeconfig=$KUBECONFIG1 get pods -l app=nse-vl3-vpp -n ns-floating-vl3-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+2.2. Find NSC and NSE in the *cluster2*:
+
+```bash
+nsc2=$(kubectl --kubeconfig=$KUBECONFIG2 get pods -l app=alpine -n ns-floating-vl3-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+```bash
+nse2=$(kubectl --kubeconfig=$KUBECONFIG2 get pods -l app=nse-vl3-vpp -n ns-floating-vl3-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+```
+
+**3. Check connectivity**
+
+3.1. NSC1 pings another client and endpoints via DNS:
+
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec $nsc1 -n ns-floating-vl3-dns -- ping -c2 -i 0.5 $nsc2.floating-vl3-dns.my.cluster3. -4
+```
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec $nsc1 -n ns-floating-vl3-dns -- ping -c2 -i 0.5 $nse2.floating-vl3-dns.my.cluster3. -4
+```
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec $nsc1 -n ns-floating-vl3-dns -- ping -c2 -i 0.5 $nse1.floating-vl3-dns.my.cluster3. -4
+```
+
+3.2. NSC2 pings another client and endpoints via DNS:
+
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 exec $nsc2 -n ns-floating-vl3-dns -- ping -c2 -i 0.5 $nsc1.floating-vl3-dns.my.cluster3. -4
+```
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 exec $nsc2 -n ns-floating-vl3-dns -- ping -c2 -i 0.5 $nse1.floating-vl3-dns.my.cluster3. -4
+```
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 exec $nsc2 -n ns-floating-vl3-dns -- ping -c2 -i 0.5 $nse2.floating-vl3-dns.my.cluster3. -4
+```
+
+## Cleanup
+
+1. Cleanup floating domain:
+```bash
+kubectl --kubeconfig=$KUBECONFIG3 delete -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-dns/cluster3?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+2. Cleanup cluster2 domain:
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 delete -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-dns/cluster2?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+3. Cleanup cluster1 domain:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 delete -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/floating_vl3-dns/cluster1?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster1/client.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-1
+  labels:
+    app: alpine
+  annotations:
+    networkservicemesh.io: kernel://floating-vl3-dns@my.cluster3/nsm-1
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3.15.0
+    imagePullPolicy: IfNotPresent
+    stdin: true
+    tty: true

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster1/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster1/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-floating-vl3-dns
+
+resources:
+  - namespace.yaml
+  - nse-vl3-vpp.yaml
+  - client.yaml

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster1/namespace.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster1/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-vl3-dns

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster1/nse-vl3-vpp.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster1/nse-vl3-vpp.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nse-vl3-vpp-2
+  name: nse-vl3-dns-vpp-1
   annotations:
-    spiffe.io/federatesWith: nsm.cluster1,nsm.cluster3
+    spiffe.io/federatesWith: nsm.cluster2,nsm.cluster3
   labels:
     app: nse-vl3-vpp
     "spiffe.io/spiffe-id": "true"
@@ -17,13 +17,15 @@ spec:
         - name: SPIFFE_ENDPOINT_SOCKET
           value: unix:///run/spire/sockets/agent.sock
         - name: NSM_NAME
-          value: "nse-vl3-vpp-2@my.cluster3"
+          value: "nse-vl3-dns-vpp-1@my.cluster3"
         - name: NSM_REGISTER_SERVICE
           value: "false"
         - name: NSM_SERVICE_NAMES
-          value: "my-interdomain-vl3-network@my.cluster3"
+          value: "floating-vl3-dns@my.cluster3"
+        - name: NSM_DNS_TEMPLATES
+          value: "{{ index .Labels \"podName\" }}.{{ target .NetworkService }}.{{ domain .NetworkService }}."
         - name: NSM_PREFIX_SERVER_URL
-          value: "tcp://vl3-ipam.ns-floating-vl3-basic.my.cluster3:5006"
+          value: "tcp://vl3-ipam.ns-floating-vl3-dns.my.cluster3:5006"
         - name: NSM_LOG_LEVEL
           value: TRACE
         - name: POD_NAME

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster2/client.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-2
+  labels:
+    app: alpine
+  annotations:
+    networkservicemesh.io: kernel://floating-vl3-dns@my.cluster3/nsm-1
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3.15.0
+    imagePullPolicy: IfNotPresent
+    stdin: true
+    tty: true

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster2/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster2/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-floating-vl3-dns
+
+resources:
+  - namespace.yaml
+  - nse-vl3-vpp.yaml
+  - client.yaml

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster2/namespace.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster2/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-vl3-dns

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster2/nse-vl3-vpp.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster2/nse-vl3-vpp.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nse-vl3-vpp-2
+  name: nse-vl3-dns-vpp-2
   annotations:
     spiffe.io/federatesWith: nsm.cluster1,nsm.cluster3
   labels:
@@ -17,13 +17,15 @@ spec:
         - name: SPIFFE_ENDPOINT_SOCKET
           value: unix:///run/spire/sockets/agent.sock
         - name: NSM_NAME
-          value: "nse-vl3-vpp-2@my.cluster3"
+          value: "nse-vl3-dns-vpp-2@my.cluster3"
         - name: NSM_REGISTER_SERVICE
           value: "false"
         - name: NSM_SERVICE_NAMES
-          value: "my-interdomain-vl3-network@my.cluster3"
+          value: "floating-vl3-dns@my.cluster3"
+        - name: NSM_DNS_TEMPLATES
+          value: "{{ index .Labels \"podName\" }}.{{ target .NetworkService }}.{{ domain .NetworkService }}."
         - name: NSM_PREFIX_SERVER_URL
-          value: "tcp://vl3-ipam.ns-floating-vl3-basic.my.cluster3:5006"
+          value: "tcp://vl3-ipam.ns-floating-vl3-dns.my.cluster3:5006"
         - name: NSM_LOG_LEVEL
           value: TRACE
         - name: POD_NAME

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster3/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster3/kustomization.yaml
@@ -2,11 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: ns-floating-vl3-basic
+namespace: ns-floating-vl3-dns
 
 resources:
   - namespace.yaml
-  - networkservice.yaml
+  - netsvc.yaml
   - ../../../../../apps/vl3-ipam
 
 patchesStrategicMerge:

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster3/namespace.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster3/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-floating-vl3-dns

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster3/netsvc.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster3/netsvc.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: networkservicemesh.io/v1
+kind: NetworkService
+metadata:
+  name: floating-vl3-dns
+spec:
+  payload: IP

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster3/patch-vl3-ipam.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster3/patch-vl3-ipam.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vl3-ipam
+spec:
+  template:
+    metadata:
+      annotations:
+        spiffe.io/federatesWith: nsm.cluster1,nsm.cluster2

--- a/examples/multicluster/usecases/interdomain_dns/README.md
+++ b/examples/multicluster/usecases/interdomain_dns/README.md
@@ -1,0 +1,70 @@
+# Interdomain DNS example
+
+This example shows how DNS works for the client if the dns server (NSE) is located on another cluster.
+Note: NSE provides DNS by itself. Also, NSE could provide configs for any other external DNS servers(that are not located as sidecar with NSE).
+
+## Requires
+
+Make sure that you have completed steps from [multicluster](../../)
+
+## Run
+
+**1. Deploy endpoint on cluster2**
+
+Deploy NSE:
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/interdomain_dns/cluster2?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+Find NSE pod by labels:
+```bash
+NSE=$(kubectl --kubeconfig=$KUBECONFIG2 get pods -l app=nse-kernel -n ns-interdomain-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+[[ ! -z $NSE ]]
+```
+
+**2. Deploy client on cluster1**
+
+Deploy client:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 apply -k https://github.com/networkservicemesh/deployments-k8s/examples/multicluster/usecases/interdomain_dns/cluster1?ref=52b52f2f2459a199c41dcd3620228ea1e92a0ba2
+```
+
+Wait for applications ready:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 wait --for=condition=ready --timeout=5m pod -l app=dnsutils -n ns-interdomain-dns
+```
+
+Find client pod by labels:
+```bash
+NSC=$(kubectl --kubeconfig=$KUBECONFIG1 get pods -l app=dnsutils -n ns-interdomain-dns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+[[ ! -z $NSC ]]
+```
+
+**3. Check connectivity**
+
+Find dns server using nslookup: 
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec ${NSC} -c dnsutils -n ns-interdomain-dns -- nslookup -norec -nodef my.coredns.service
+```
+
+Ping from dnsutils to NSE by domain name:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec ${NSC} -c dnsutils -n ns-interdomain-dns -- ping -c 4 my.coredns.service
+```
+
+Validate that the default DNS server is working:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 exec ${NSC} -c dnsutils -n ns-interdomain-dns -- dig kubernetes.default A kubernetes.default AAAA | grep "kubernetes.default.svc.cluster.local"
+```
+
+## Cleanup
+
+1. Cleanup resources for *cluster1*:
+```bash
+kubectl --kubeconfig=$KUBECONFIG1 delete ns ns-interdomain-dns
+```
+
+2. Cleanup resources for *cluster2*:
+```bash
+kubectl --kubeconfig=$KUBECONFIG2 delete ns ns-interdomain-dns
+```

--- a/examples/multicluster/usecases/interdomain_dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster1/client.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: dnsutils
   annotations:
-    networkservicemesh.io: kernel://dns@my.cluster2/nsm-1
+    networkservicemesh.io: kernel://interdomain-dns@my.cluster2/nsm-1
 spec:
   containers:
     - name: dnsutils

--- a/examples/multicluster/usecases/interdomain_dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster1/client.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dnsutils
+  labels:
+    app: dnsutils
+  annotations:
+    networkservicemesh.io: kernel://dns@my.cluster2/nsm-1
+spec:
+  containers:
+    - name: dnsutils
+      image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
+      imagePullPolicy: IfNotPresent
+      stdin: true
+      tty: true

--- a/examples/multicluster/usecases/interdomain_dns/cluster1/kustomization.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster1/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-interdomain-dns
+
+resources:
+- namespace.yaml
+- client.yaml

--- a/examples/multicluster/usecases/interdomain_dns/cluster1/namespace.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster1/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-interdomain-dns

--- a/examples/multicluster/usecases/interdomain_dns/cluster2/coredns-config-map.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster2/coredns-config-map.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+data:
+  Corefile: |
+    . {
+        log
+        hosts {
+            no_recursive
+            172.16.1.2 my.coredns.service.
+        }
+    }

--- a/examples/multicluster/usecases/interdomain_dns/cluster2/kustomization.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster2/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-interdomain-dns
+
+resources:
+- namespace.yaml
+- coredns-config-map.yaml
+- ../../../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nse.yaml

--- a/examples/multicluster/usecases/interdomain_dns/cluster2/namespace.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster2/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-interdomain-dns

--- a/examples/multicluster/usecases/interdomain_dns/cluster2/patch-nse.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster2/patch-nse.yaml
@@ -12,7 +12,7 @@ spec:
             - name: NSM_CIDR_PREFIX
               value: 172.16.1.2/31
             - name: NSM_SERVICE_NAMES
-              value: "dns"
+              value: "interdomain-dns"
             - name: NSM_DNS_CONFIGS
               value: "[{\"dns_server_ips\": [\"172.16.1.2\"], \"search_domains\": [\"my.coredns.service\"]}]"
         - name: coredns

--- a/examples/multicluster/usecases/interdomain_dns/cluster2/patch-nse.yaml
+++ b/examples/multicluster/usecases/interdomain_dns/cluster2/patch-nse.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSM_CIDR_PREFIX
+              value: 172.16.1.2/31
+            - name: NSM_SERVICE_NAMES
+              value: "dns"
+            - name: NSM_DNS_CONFIGS
+              value: "[{\"dns_server_ips\": [\"172.16.1.2\"], \"search_domains\": [\"my.coredns.service\"]}]"
+        - name: coredns
+          image: coredns/coredns:1.8.3
+          imagePullPolicy: IfNotPresent
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+              readOnly: true
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+              - key: Corefile
+                path: Corefile


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This PR adds interdomain DNS examples:
- Interdomain DNS
- Floating interdomain DNS
- Floating interdomain VL3 DNS 


## Issue link
Closes: https://github.com/networkservicemesh/deployments-k8s/issues/8901


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
