### PR TITLE
Remove `bases` from kustomization files

### DIFF
--- a/examples/multicluster/usecases/floating_nse_composition/cluster1/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_nse_composition/cluster1/kustomization.yaml
@@ -4,11 +4,9 @@ kind: Kustomization
 
 namespace: ns-interdomain-nse-composition
 
-bases:
+resources:
 - nse-firewall
 - nse-passthrough-1
-
-resources:
 - ns-interdomain-nse-composition.yaml
 - client.yaml
 - config-file.yaml

--- a/examples/multicluster/usecases/floating_nse_composition/cluster1/nse-firewall/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_nse_composition/cluster1/nse-firewall/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 namespace: ns-interdomain-nse-composition
 
-bases:
+resources:
 - ../../../../../../apps/nse-firewall-vpp
 
 patchesStrategicMerge:

--- a/examples/multicluster/usecases/floating_nse_composition/cluster2/kustomization.yaml
+++ b/examples/multicluster/usecases/floating_nse_composition/cluster2/kustomization.yaml
@@ -4,16 +4,14 @@ kind: Kustomization
 
 namespace: ns-interdomain-nse-composition
 
-bases:
+resources:
 - ../../../../../apps/nse-kernel
 - nse-passthrough-2
 - nse-passthrough-3
+- ns-interdomain-nse-composition.yaml
 
 patchesStrategicMerge:
 - patch-nse.yaml
-
-resources:
-- ns-interdomain-nse-composition.yaml
 
 configMapGenerator:
   - name: nginx-config


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->


## Motivation
`bases` section in kustomization.yaml files is deprecated now.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [x] Refactoring
- [ ] CI
