### PR TITLE
Add request memory values for `nse-firewall-vpp` and `forwarder-vpp`

### DIFF
--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -57,6 +57,7 @@ spec:
               mountPath: /var/run/vpp/external
           resources:
             requests:
+              memory: 350Mi
               cpu: 150m
             limits:
               memory: 500Mi

--- a/apps/nse-firewall-vpp/nse.yaml
+++ b/apps/nse-firewall-vpp/nse.yaml
@@ -41,10 +41,10 @@ spec:
               readOnly: true
           resources:
             requests:
-              memory: 325Mi
+              memory: 300Mi
               cpu: 150m
             limits:
-              memory: 450Mi
+              memory: 350Mi
               cpu: 500m
       volumes:
         - name: spire-agent-socket

--- a/apps/nse-firewall-vpp/nse.yaml
+++ b/apps/nse-firewall-vpp/nse.yaml
@@ -41,6 +41,7 @@ spec:
               readOnly: true
           resources:
             requests:
+              memory: 325Mi
               cpu: 150m
             limits:
               memory: 450Mi


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Current `nse-firewall-vpp` and `forwarder-vpp` yaml files doesn't have memory requests, only memory limits. This PR adds memory requests for them based on these measurements:

```
NAME                                     CPU(cores)   MEMORY(bytes)
admission-webhook-k8s-84df466557-h6mw2   1m           20Mi
forwarder-vpp-477zp                      55m          324Mi
forwarder-vpp-s2fgm                      93m          336Mi
nsmgr-26w6p                              41m          67Mi
nsmgr-cqj8g                              16m          41Mi
registry-k8s-896d4b5c5-944dw             14m          33Mi
```

```
NAME                                 CPU(cores)   MEMORY(bytes)
alpine                               17m          17Mi
nse-firewall-vpp-6c5c6d4bd9-45q9z    383m         315Mi
nse-kernel-5b457b54d8-4xhsx          1m           25Mi
nse-passthrough-1-674b4fb94c-z7r9t   31m          245Mi
nse-passthrough-2-5cc74c66dd-lxhd2   347m         240Mi
nse-passthrough-3-6f98789d49-7nfsl   31m          245Mi
```

## Issue link
https://github.com/networkservicemesh/integration-k8s-aks/issues/275


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
