### PR TITLE
Fix SRIOV examples to work with VLAN tags

### DIFF
--- a/apps/nse-kernel-ponger/ponger-configmap.yaml
+++ b/apps/nse-kernel-ponger/ponger-configmap.yaml
@@ -20,21 +20,40 @@ data:
       ip addr del ${addr}
     }
 
+    function delete_interface() {
+      link="$1"
+      vlanTag="$2"
+      ip link del link ${link} name ${link}.${vlanTag}
+    }
+
     link="$1"
     dst_ip_subnet="$2"
     src_ip_subnet="$3"
+    vlanTag="$4"
 
     dst_ip_addr="$(echo "${dst_ip_subnet}" | sed -E 's/(.*)\/.*/\1/g')"
 
     addr="dev ${link} ${dst_ip_subnet}"
     route="${src_ip_subnet} via ${dst_ip_addr} dev ${link}"
 
-    # Don't forget to delete IP address on exit
-    trap "delete_IP_route \"${addr}\" \"${route}\"" err exit
+    # If VLAN tag was set
+    if [[ $vlanTag -ne 0 ]]; then
+        addr="dev ${link}.${vlanTag} ${dst_ip_subnet}"
+        route="${src_ip_subnet} via ${dst_ip_addr} dev ${link}.${vlanTag}"
+        ip link add link ${link} name ${link}.${vlanTag} type vlan id ${vlanTag}
+        trap "delete_interface \"${link}\" \"${vlanTag}\"" err exit
+    else
+        # Don't forget to delete IP address on exit
+        trap "delete_IP_route \"${addr}\" \"${route}\"" err exit
+    fi
 
     # Add IP address and wake up the link
     ip addr add ${addr}
     ip link set dev "${link}" up || exit 2
+
+    if [[ $vlanTag -ne 0 ]]; then
+        ip link set dev "${link}.${vlanTag}" up || exit 3
+    fi
 
     # Add IP route
     ip route add ${route}

--- a/apps/nse-kernel-ponger/ponger.yaml
+++ b/apps/nse-kernel-ponger/ponger.yaml
@@ -20,7 +20,7 @@ spec:
         - name: ponger
           image: frolvlad/alpine-bash:latest
           imagePullPolicy: IfNotPresent
-          command: ["bin/bash", "root/scripts/pong.sh", "ens6f3", "172.16.1.100/32", "172.16.1.101/32"]
+          command: ["bin/bash", "root/scripts/pong.sh", "ens6f3", "172.16.1.100/32", "172.16.1.101/32", "1044"]
           securityContext:
             privileged: true
           volumeMounts:

--- a/apps/nse-noop/kustomization.yaml
+++ b/apps/nse-noop/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- nse.yaml

--- a/apps/nse-noop/nse.yaml
+++ b/apps/nse-noop/nse.yaml
@@ -2,35 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nse-vfio
+  name: nse-noop
   labels:
-    app: nse-vfio
+    app: nse-noop
 spec:
   selector:
     matchLabels:
-      app: nse-vfio
+      app: nse-noop
   template:
     metadata:
       labels:
-        app: nse-vfio
+        app: nse-noop
         "spiffe.io/spiffe-id": "true"
     spec:
       hostNetwork: true
       containers:
-        - name: ponger
-          # https://github.com/glazychev-art/docker-dpdk
-          image: artgl/dpdk-pingpong:20.11.6
-          imagePullPolicy: IfNotPresent
-          command: ["/bin/bash", "/root/scripts/pong.sh", "ens6f3", "31", "0a:55:44:33:22:11", "1044"]
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: scripts
-              mountPath: /root/scripts
-              readOnly: true
-            - name: vfio
-              mountPath: /dev/vfio
-
         - name: nse
           image: ghcr.io/networkservicemesh/ci/cmd-nse-vfio:dc4e583
           env:
@@ -64,9 +50,6 @@ spec:
               master.domain/10G: 1
 
       volumes:
-        - name: scripts
-          configMap:
-            name: nse-vfio
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/sockets
@@ -75,7 +58,3 @@ spec:
           hostPath:
             path: /var/lib/networkservicemesh
             type: Directory
-        - name: vfio
-          hostPath:
-            path: /dev/vfio
-            type: DirectoryOrCreate

--- a/apps/nse-vfio/nse-configmap.yaml
+++ b/apps/nse-vfio/nse-configmap.yaml
@@ -32,6 +32,12 @@ data:
       return 0
     }
 
+    function cleanup_vlan_interface() {
+      pf_link="$1"
+      vf_num="$2"
+      ip link set ${pf_link} vf ${vf_num} vlan 0
+    }
+
     ##
     ## Begin
     ##
@@ -39,6 +45,7 @@ data:
     pf_link="$1"
     vf_num="$2"
     server_mac="$3"
+    vlanTag="$4"
 
     device="/sys/class/net/${pf_link}/device/virtfn${vf_num}"
 
@@ -53,6 +60,14 @@ data:
     # Bind VFIO driver
     bind_driver "${pci_addr}" "vfio-pci"
     test $? -eq 0 || exit 3
+
+    # If VLAN tag was set
+    if [[ $vlanTag -ne 0 ]]; then
+        apt-get update
+        apt-get -y install iproute2
+        ip link set "${pf_link}" vf "${vf_num}" vlan "${vlanTag}"
+        trap "cleanup_vlan_interface \"${pf_link}\" \"${vf_num}\"" err exit
+    fi
 
     # Run dpdk-pingpong (server)
     /root/dpdk-pingpong/build/pingpong \

--- a/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/README.md
@@ -1,6 +1,7 @@
 # Test kernel to Ethernet to kernel connection and VFIO connection
 
 This example shows that remote kernel over Ethernet connection and VFIO connection can be setup by NSM at the same time.
+SR-IOV VF uses VLAN tag.
 
 ## Run
 

--- a/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/patch-nse-vfio.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/patch-nse-vfio.yaml
@@ -9,7 +9,9 @@ spec:
       containers:
         - name: nse
           env:
+            - name: NSM_LABELS
+              value: serviceDomain:worker.domain
             - name: NSM_SERVICE_NAMES
-              value: "vfio2noop@worker.domain: { addr: 0a:55:44:33:22:11 }"
+              value: "vfio2noop: { addr: 0a:55:44:33:22:11; vlan: 1044 }"
             - name: NSM_REGISTER_SERVICE
               value: "false"

--- a/examples/use-cases/Kernel2Kernel_Vfio2Noop/README.md
+++ b/examples/use-cases/Kernel2Kernel_Vfio2Noop/README.md
@@ -1,6 +1,7 @@
 # Test kernel to kernel connection and VFIO connection
 
 This example shows that local kernel connection and VFIO connection can be setup by NSM at the same time.
+SR-IOV VF uses VLAN tag.
 
 ## Run
 

--- a/examples/use-cases/Kernel2Kernel_Vfio2Noop/patch-nse-vfio.yaml
+++ b/examples/use-cases/Kernel2Kernel_Vfio2Noop/patch-nse-vfio.yaml
@@ -9,7 +9,9 @@ spec:
       containers:
         - name: nse
           env:
+            - name: NSM_LABELS
+              value: serviceDomain:worker.domain
             - name: NSM_SERVICE_NAMES
-              value: "vfio2noop@worker.domain: { addr: 0a:55:44:33:22:11 }"
+              value: "vfio2noop: { addr: 0a:55:44:33:22:11; vlan: 1044 }"
             - name: NSM_REGISTER_SERVICE
               value: "false"

--- a/examples/use-cases/SriovKernel2Noop/README.md
+++ b/examples/use-cases/SriovKernel2Noop/README.md
@@ -1,6 +1,7 @@
 # Test SR-IOV kernel connection
 
 This example shows that NSC and NSE can work with each other over the SR-IOV kernel connection.
+SR-IOV VF uses VLAN tag
 
 ## Requires
 
@@ -33,7 +34,7 @@ Wait for applications ready:
 kubectl -n ns-sriov-kernel2noop wait --for=condition=ready --timeout=1m pod -l app=nsc-kernel
 ```
 ```bash
-kubectl -n ns-sriov-kernel2noop wait --for=condition=ready --timeout=1m pod -l app=nse-kernel
+kubectl -n ns-sriov-kernel2noop wait --for=condition=ready --timeout=1m pod -l app=nse-noop
 ```
 
 Ping from NSC to NSE:

--- a/examples/use-cases/SriovKernel2Noop/kustomization.yaml
+++ b/examples/use-cases/SriovKernel2Noop/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: ns-sriov-kernel2noop
 
 resources:
 - ../../../apps/nsc-kernel
-- ../../../apps/nse-kernel
+- ../../../apps/nse-noop
 - namespace
 - netsvc.yaml
 

--- a/examples/use-cases/SriovKernel2Noop/patch-nse.yaml
+++ b/examples/use-cases/SriovKernel2Noop/patch-nse.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nse-kernel
+  name: nse-noop
 spec:
   template:
     spec:
@@ -14,7 +14,7 @@ spec:
             - name: NSM_CIDR_PREFIX
               value: 172.16.1.100/31
             - name: NSM_SERVICE_NAMES
-              value: "sriov-kernel2noop"
+              value: "sriov-kernel2noop: { vlan: 1044 }"
             - name: NSM_REGISTER_SERVICE
               value: "false"
           resources:

--- a/examples/use-cases/Vfio2Noop/README.md
+++ b/examples/use-cases/Vfio2Noop/README.md
@@ -1,6 +1,7 @@
 # Test VFIO connection
 
 This example shows that NSC and NSE can work with each other over the VFIO connection.
+SR-IOV VF uses VLAN tag
 
 ## Requires
 

--- a/examples/use-cases/Vfio2Noop/patch-nse-vfio.yaml
+++ b/examples/use-cases/Vfio2Noop/patch-nse-vfio.yaml
@@ -9,7 +9,9 @@ spec:
       containers:
         - name: nse
           env:
+            - name: NSM_LABELS
+              value: serviceDomain:worker.domain
             - name: NSM_SERVICE_NAMES
-              value: "vfio2noop@worker.domain: { addr: 0a:55:44:33:22:11 }"
+              value: "vfio2noop: { addr: 0a:55:44:33:22:11; vlan: 1044 }"
             - name: NSM_REGISTER_SERVICE
               value: "false"


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
To work with VLAN tags, we need slightly change the configuration of the examples.

## Issue link
https://github.com/networkservicemesh/sdk-sriov/issues/489


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
