### PR TITLE
Fix slow `kubectl delete` in tests using special shell command

### DIFF
--- a/examples/features/annotated-namespace/client.yaml
+++ b/examples/features/annotated-namespace/client.yaml
@@ -18,4 +18,6 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
+          # simple `sleep` command would work
+          # but we need `trap` to be able to delete pods quckly
           command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/annotated-namespace/client.yaml
+++ b/examples/features/annotated-namespace/client.yaml
@@ -18,5 +18,4 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
-          stdin: true
-          tty: true
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/dns/dnsutils.yaml
+++ b/examples/features/dns/dnsutils.yaml
@@ -13,8 +13,7 @@ spec:
   - name: dnsutils
     image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/dns/dnsutils.yaml
+++ b/examples/features/dns/dnsutils.yaml
@@ -13,6 +13,8 @@ spec:
   - name: dnsutils
     image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/features/dual-stack/Kernel2IP2Kernel_dual_stack/client.yaml
+++ b/examples/features/dual-stack/Kernel2IP2Kernel_dual_stack/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/features/dual-stack/Kernel2IP2Kernel_dual_stack/client.yaml
+++ b/examples/features/dual-stack/Kernel2IP2Kernel_dual_stack/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/dual-stack/Kernel2Kernel_dual_stack/client.yaml
+++ b/examples/features/dual-stack/Kernel2Kernel_dual_stack/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/dual-stack/Kernel2Kernel_dual_stack/client.yaml
+++ b/examples/features/dual-stack/Kernel2Kernel_dual_stack/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/features/exclude-prefixes-client/client.yaml
+++ b/examples/features/exclude-prefixes-client/client.yaml
@@ -12,4 +12,6 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/exclude-prefixes-client/client.yaml
+++ b/examples/features/exclude-prefixes-client/client.yaml
@@ -12,5 +12,4 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-      stdin: true
-      tty: true
+      command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/exclude-prefixes-client/client.yaml
+++ b/examples/features/exclude-prefixes-client/client.yaml
@@ -12,6 +12,6 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-    # simple `sleep` command would work
-    # but we need `trap` to be able to delete pods quckly
+      # simple `sleep` command would work
+      # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/exclude-prefixes/client.yaml
+++ b/examples/features/exclude-prefixes/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/exclude-prefixes/client.yaml
+++ b/examples/features/exclude-prefixes/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/features/ipv6/Kernel2IP2Kernel_ipv6/client.yaml
+++ b/examples/features/ipv6/Kernel2IP2Kernel_ipv6/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/features/ipv6/Kernel2IP2Kernel_ipv6/client.yaml
+++ b/examples/features/ipv6/Kernel2IP2Kernel_ipv6/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/ipv6/Kernel2IP2Memif_ipv6/client.yaml
+++ b/examples/features/ipv6/Kernel2IP2Memif_ipv6/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/features/ipv6/Kernel2IP2Memif_ipv6/client.yaml
+++ b/examples/features/ipv6/Kernel2IP2Memif_ipv6/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/ipv6/Kernel2Kernel_ipv6/client.yaml
+++ b/examples/features/ipv6/Kernel2Kernel_ipv6/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/ipv6/Kernel2Kernel_ipv6/client.yaml
+++ b/examples/features/ipv6/Kernel2Kernel_ipv6/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/features/nse-composition/client.yaml
+++ b/examples/features/nse-composition/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/nse-composition/client.yaml
+++ b/examples/features/nse-composition/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/features/policy-based-routing/client.yaml
+++ b/examples/features/policy-based-routing/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: nettools
     image: travelping/nettools:1.10.1
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/features/policy-based-routing/client.yaml
+++ b/examples/features/policy-based-routing/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: nettools
     image: travelping/nettools:1.10.1
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/scale-from-zero/client.yaml
+++ b/examples/features/scale-from-zero/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/features/scale-from-zero/client.yaml
+++ b/examples/features/scale-from-zero/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/select-forwarder/client.yaml
+++ b/examples/features/select-forwarder/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
     resources:
       requests:

--- a/examples/features/select-forwarder/client.yaml
+++ b/examples/features/select-forwarder/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
     resources:
       requests:
         cpu: 50m

--- a/examples/features/vl3-basic/client.yaml
+++ b/examples/features/vl3-basic/client.yaml
@@ -21,4 +21,6 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
+        # simple `sleep` command would work
+        # but we need `trap` to be able to delete pods quckly
         command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/vl3-basic/client.yaml
+++ b/examples/features/vl3-basic/client.yaml
@@ -21,5 +21,4 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
-        stdin: true
-        tty: true
+        command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/vl3-dns/nsc.yaml
+++ b/examples/features/vl3-dns/nsc.yaml
@@ -21,4 +21,6 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
+        # simple `sleep` command would work
+        # but we need `trap` to be able to delete pods quckly
         command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/vl3-dns/nsc.yaml
+++ b/examples/features/vl3-dns/nsc.yaml
@@ -21,5 +21,4 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
-        stdin: true
-        tty: true
+        command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/vl3-scale-from-zero/client.yaml
+++ b/examples/features/vl3-scale-from-zero/client.yaml
@@ -21,4 +21,6 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
+        # simple `sleep` command would work
+        # but we need `trap` to be able to delete pods quckly
         command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/vl3-scale-from-zero/client.yaml
+++ b/examples/features/vl3-scale-from-zero/client.yaml
@@ -21,5 +21,4 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
-        stdin: true
-        tty: true
+        command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/features/webhook/client.yaml
+++ b/examples/features/webhook/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: nettools
     image: travelping/nettools:1.10.1
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/features/webhook/client.yaml
+++ b/examples/features/webhook/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: nettools
     image: travelping/nettools:1.10.1
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/dataplane-interrupt/client.yaml
+++ b/examples/heal/dataplane-interrupt/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
     securityContext:
       capabilities:
         add: ["NET_ADMIN"]

--- a/examples/heal/dataplane-interrupt/client.yaml
+++ b/examples/heal/dataplane-interrupt/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
     securityContext:
       capabilities:

--- a/examples/heal/local-forwarder-death/client.yaml
+++ b/examples/heal/local-forwarder-death/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/local-forwarder-death/client.yaml
+++ b/examples/heal/local-forwarder-death/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/heal/local-forwarder-remote-forwarder/client.yaml
+++ b/examples/heal/local-forwarder-remote-forwarder/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/local-forwarder-remote-forwarder/client.yaml
+++ b/examples/heal/local-forwarder-remote-forwarder/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/local-nse-death/base/client.yaml
+++ b/examples/heal/local-nse-death/base/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/local-nse-death/base/client.yaml
+++ b/examples/heal/local-nse-death/base/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/heal/local-nsm-system-restart/client.yaml
+++ b/examples/heal/local-nsm-system-restart/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/local-nsm-system-restart/client.yaml
+++ b/examples/heal/local-nsm-system-restart/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/heal/local-nsmgr-remote-nsmgr/client.yaml
+++ b/examples/heal/local-nsmgr-remote-nsmgr/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/local-nsmgr-remote-nsmgr/client.yaml
+++ b/examples/heal/local-nsmgr-remote-nsmgr/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/local-nsmgr-restart/client.yaml
+++ b/examples/heal/local-nsmgr-restart/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/local-nsmgr-restart/client.yaml
+++ b/examples/heal/local-nsmgr-restart/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/registry-local-endpoint/base/client.yaml
+++ b/examples/heal/registry-local-endpoint/base/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/registry-local-endpoint/base/client.yaml
+++ b/examples/heal/registry-local-endpoint/base/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/heal/registry-remote-forwarder/client.yaml
+++ b/examples/heal/registry-remote-forwarder/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/registry-remote-forwarder/client.yaml
+++ b/examples/heal/registry-remote-forwarder/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/registry-remote-nsmgr/client.yaml
+++ b/examples/heal/registry-remote-nsmgr/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/registry-remote-nsmgr/client.yaml
+++ b/examples/heal/registry-remote-nsmgr/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/registry-restart/registry-after-death/client.yaml
+++ b/examples/heal/registry-restart/registry-after-death/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/registry-restart/registry-after-death/client.yaml
+++ b/examples/heal/registry-restart/registry-after-death/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/heal/registry-restart/registry-before-death/client.yaml
+++ b/examples/heal/registry-restart/registry-before-death/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/registry-restart/registry-before-death/client.yaml
+++ b/examples/heal/registry-restart/registry-before-death/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/heal/remote-forwarder-death-ip/client.yaml
+++ b/examples/heal/remote-forwarder-death-ip/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-forwarder-death-ip/client.yaml
+++ b/examples/heal/remote-forwarder-death-ip/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/remote-forwarder-death/client.yaml
+++ b/examples/heal/remote-forwarder-death/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-forwarder-death/client.yaml
+++ b/examples/heal/remote-forwarder-death/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/remote-nse-death-ip/base/client.yaml
+++ b/examples/heal/remote-nse-death-ip/base/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-nse-death-ip/base/client.yaml
+++ b/examples/heal/remote-nse-death-ip/base/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/remote-nse-death/base/client.yaml
+++ b/examples/heal/remote-nse-death/base/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-nse-death/base/client.yaml
+++ b/examples/heal/remote-nse-death/base/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/remote-nsmgr-death/remote-nse/client.yaml
+++ b/examples/heal/remote-nsmgr-death/remote-nse/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/heal/remote-nsmgr-death/remote-nse/client.yaml
+++ b/examples/heal/remote-nsmgr-death/remote-nse/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/heal/remote-nsmgr-remote-endpoint/nsmgr-before-death/client.yaml
+++ b/examples/heal/remote-nsmgr-remote-endpoint/nsmgr-before-death/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-nsmgr-remote-endpoint/nsmgr-before-death/client.yaml
+++ b/examples/heal/remote-nsmgr-remote-endpoint/nsmgr-before-death/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/remote-nsmgr-restart-ip/client.yaml
+++ b/examples/heal/remote-nsmgr-restart-ip/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-nsmgr-restart-ip/client.yaml
+++ b/examples/heal/remote-nsmgr-restart-ip/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/remote-nsmgr-restart/client.yaml
+++ b/examples/heal/remote-nsmgr-restart/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/remote-nsmgr-restart/client.yaml
+++ b/examples/heal/remote-nsmgr-restart/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/spire-agent-restart/client.yaml
+++ b/examples/heal/spire-agent-restart/client.yaml
@@ -12,8 +12,7 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-      stdin: true
-      tty: true
+      command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/spire-agent-restart/client.yaml
+++ b/examples/heal/spire-agent-restart/client.yaml
@@ -12,8 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-    # simple `sleep` command would work
-    # but we need `trap` to be able to delete pods quckly
+      # simple `sleep` command would work
+      # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-agent-restart/client.yaml
+++ b/examples/heal/spire-agent-restart/client.yaml
@@ -12,6 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-server-agent-restart/client.yaml
+++ b/examples/heal/spire-server-agent-restart/client.yaml
@@ -12,8 +12,7 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-      stdin: true
-      tty: true
+      command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/spire-server-agent-restart/client.yaml
+++ b/examples/heal/spire-server-agent-restart/client.yaml
@@ -12,8 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-    # simple `sleep` command would work
-    # but we need `trap` to be able to delete pods quckly
+      # simple `sleep` command would work
+      # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-server-agent-restart/client.yaml
+++ b/examples/heal/spire-server-agent-restart/client.yaml
@@ -12,6 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-server-restart/client.yaml
+++ b/examples/heal/spire-server-restart/client.yaml
@@ -12,8 +12,7 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-      stdin: true
-      tty: true
+      command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/spire-server-restart/client.yaml
+++ b/examples/heal/spire-server-restart/client.yaml
@@ -12,8 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-    # simple `sleep` command would work
-    # but we need `trap` to be able to delete pods quckly
+      # simple `sleep` command would work
+      # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-server-restart/client.yaml
+++ b/examples/heal/spire-server-restart/client.yaml
@@ -12,6 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-upgrade/client.yaml
+++ b/examples/heal/spire-upgrade/client.yaml
@@ -12,8 +12,7 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-      stdin: true
-      tty: true
+      command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/heal/spire-upgrade/client.yaml
+++ b/examples/heal/spire-upgrade/client.yaml
@@ -12,8 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
-    # simple `sleep` command would work
-    # but we need `trap` to be able to delete pods quckly
+      # simple `sleep` command would work
+      # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/spire-upgrade/client.yaml
+++ b/examples/heal/spire-upgrade/client.yaml
@@ -12,6 +12,8 @@ spec:
     - name: alpine
       image: alpine:3.15.0
       imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/heal/vl3-nscs-death/client.yaml
+++ b/examples/heal/vl3-nscs-death/client.yaml
@@ -21,4 +21,6 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
+        # simple `sleep` command would work
+        # but we need `trap` to be able to delete pods quckly
         command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/heal/vl3-nscs-death/client.yaml
+++ b/examples/heal/vl3-nscs-death/client.yaml
@@ -21,5 +21,4 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
-        stdin: true
-        tty: true
+        command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/heal/vl3-nse-death/client.yaml
+++ b/examples/heal/vl3-nse-death/client.yaml
@@ -21,4 +21,6 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
+        # simple `sleep` command would work
+        # but we need `trap` to be able to delete pods quckly
         command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/heal/vl3-nse-death/client.yaml
+++ b/examples/heal/vl3-nse-death/client.yaml
@@ -21,5 +21,4 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
-        stdin: true
-        tty: true
+        command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/interdomain/nsm_istio/greeting/client.yaml
+++ b/examples/interdomain/nsm_istio/greeting/client.yaml
@@ -21,5 +21,4 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
-          stdin: true
-          tty: true
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/interdomain/nsm_istio/greeting/client.yaml
+++ b/examples/interdomain/nsm_istio/greeting/client.yaml
@@ -21,4 +21,6 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
+          # simple `sleep` command would work
+          # but we need `trap` to be able to delete pods quckly
           command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/k8s_monolith/external_nse/usecases/Kernel2IP2Kernel/client.yaml
+++ b/examples/k8s_monolith/external_nse/usecases/Kernel2IP2Kernel/client.yaml
@@ -21,4 +21,6 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
+        # simple `sleep` command would work
+        # but we need `trap` to be able to delete pods quckly
         command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/k8s_monolith/external_nse/usecases/Kernel2IP2Kernel/client.yaml
+++ b/examples/k8s_monolith/external_nse/usecases/Kernel2IP2Kernel/client.yaml
@@ -21,5 +21,4 @@ spec:
       - name: alpine
         image: alpine:3.15.0
         imagePullPolicy: IfNotPresent
-        stdin: true
-        tty: true
+        command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/memory/Kernel2Ethernet2Kernel/client.yaml
+++ b/examples/memory/Kernel2Ethernet2Kernel/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/memory/Kernel2Ethernet2Kernel/client.yaml
+++ b/examples/memory/Kernel2Ethernet2Kernel/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/memory/Kernel2Kernel/client.yaml
+++ b/examples/memory/Kernel2Kernel/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/memory/Kernel2Kernel/client.yaml
+++ b/examples/memory/Kernel2Kernel/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/multicluster/usecases/floating_Kernel2Ethernet2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_Kernel2Ethernet2Kernel/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_Kernel2Ethernet2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_Kernel2Ethernet2Kernel/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_Kernel2IP2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_Kernel2IP2Kernel/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_Kernel2IP2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_Kernel2IP2Kernel/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
     - name: dnsutils
       image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
       imagePullPolicy: IfNotPresent
+      # simple `sleep` command would work
+      # but we need `trap` to be able to delete pods quckly
       command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_dns/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
     - name: dnsutils
       image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
       imagePullPolicy: IfNotPresent
-      stdin: true
-      tty: true
+      command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_nse_composition/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_nse_composition/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_nse_composition/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_nse_composition/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster2/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-basic/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-basic/cluster2/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster2/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-dns/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-dns/cluster2/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster1/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster2/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster2/client.yaml
+++ b/examples/multicluster/usecases/floating_vl3-scale-from-zero/cluster2/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/interdomain_Kernel2Ethernet2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/interdomain_Kernel2Ethernet2Kernel/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/interdomain_Kernel2Ethernet2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/interdomain_Kernel2Ethernet2Kernel/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/interdomain_Kernel2IP2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/interdomain_Kernel2IP2Kernel/cluster1/client.yaml
@@ -12,4 +12,6 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/multicluster/usecases/interdomain_Kernel2IP2Kernel/cluster1/client.yaml
+++ b/examples/multicluster/usecases/interdomain_Kernel2IP2Kernel/cluster1/client.yaml
@@ -12,5 +12,4 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/observability/jaeger-and-prometheus/example/client.yaml
+++ b/examples/observability/jaeger-and-prometheus/example/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/observability/jaeger-and-prometheus/example/client.yaml
+++ b/examples/observability/jaeger-and-prometheus/example/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/use-cases/Kernel2Ethernet2Kernel/client.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Kernel/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/use-cases/Kernel2Ethernet2Kernel/client.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Kernel/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/client.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/client.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Kernel_Vfio2Noop/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2Ethernet2Memif/client.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Memif/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/use-cases/Kernel2Ethernet2Memif/client.yaml
+++ b/examples/use-cases/Kernel2Ethernet2Memif/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2IP2Kernel/client.yaml
+++ b/examples/use-cases/Kernel2IP2Kernel/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/use-cases/Kernel2IP2Kernel/client.yaml
+++ b/examples/use-cases/Kernel2IP2Kernel/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2IP2Memif/client.yaml
+++ b/examples/use-cases/Kernel2IP2Memif/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:

--- a/examples/use-cases/Kernel2IP2Memif/client.yaml
+++ b/examples/use-cases/Kernel2IP2Memif/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2Kernel/client.yaml
+++ b/examples/use-cases/Kernel2Kernel/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2Kernel/client.yaml
+++ b/examples/use-cases/Kernel2Kernel/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/use-cases/Kernel2Kernel_Vfio2Noop/client.yaml
+++ b/examples/use-cases/Kernel2Kernel_Vfio2Noop/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2Kernel_Vfio2Noop/client.yaml
+++ b/examples/use-cases/Kernel2Kernel_Vfio2Noop/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/use-cases/Kernel2Memif/client.yaml
+++ b/examples/use-cases/Kernel2Memif/client.yaml
@@ -12,8 +12,7 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
-    stdin: true
-    tty: true
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/use-cases/Kernel2Memif/client.yaml
+++ b/examples/use-cases/Kernel2Memif/client.yaml
@@ -12,6 +12,8 @@ spec:
   - name: alpine
     image: alpine:3.15.0
     imagePullPolicy: IfNotPresent
+    # simple `sleep` command would work
+    # but we need `trap` to be able to delete pods quckly
     command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
   affinity:
     podAffinity:

--- a/examples/use-cases/Kernel2RVlanMultiNS/client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/client.yaml
@@ -31,5 +31,4 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
-          stdin: true
-          tty: true
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/client.yaml
@@ -31,4 +31,6 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
+          # simple `sleep` command would work
+          # but we need `trap` to be able to delete pods quckly
           command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/ns-1/first-client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/ns-1/first-client.yaml
@@ -31,5 +31,4 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
-          stdin: true
-          tty: true
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/ns-1/first-client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/ns-1/first-client.yaml
@@ -31,4 +31,6 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
+          # simple `sleep` command would work
+          # but we need `trap` to be able to delete pods quckly
           command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/ns-2/second-client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/ns-2/second-client.yaml
@@ -31,5 +31,4 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
-          stdin: true
-          tty: true
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/ns-2/second-client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/ns-2/second-client.yaml
@@ -31,4 +31,6 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
+          # simple `sleep` command would work
+          # but we need `trap` to be able to delete pods quckly
           command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/ns-2/third-client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/ns-2/third-client.yaml
@@ -31,5 +31,4 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
-          stdin: true
-          tty: true
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/examples/use-cases/Kernel2RVlanMultiNS/ns-2/third-client.yaml
+++ b/examples/use-cases/Kernel2RVlanMultiNS/ns-2/third-client.yaml
@@ -31,4 +31,6 @@ spec:
         - name: alpine
           image: alpine:3.15.0
           imagePullPolicy: IfNotPresent
+          # simple `sleep` command would work
+          # but we need `trap` to be able to delete pods quckly
           command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

`kubectl delete` in the cleanup section of tests is slow because of our client setup.
We use:
```yaml
image: alpine
# we don't set the command but /bin/sh is set in the alpine Dockerfile
command: [ '/bin/sh' ]
stdin: true
tty: true
```

`sh` here doesn't respond to SIGTERM, so k8s waits the grace period, which is 30 seconds by default, which increases the cleanup duration in our tests.

In this PR I use a proper command that responds to signals:
```bash
/bin/sh -c "trap : TERM INT; sleep infinity & wait"
```

In my local testing `kubectl delete ns` takes 40-45 seconds before this change, and 10-13 seconds with this change.
Though, memif tests are not affected, because the didn't use this hanging alpine container in the first place.

## Issue link
<!--- Please link to the issue here. -->

https://github.com/networkservicemesh/deployments-k8s/issues/9128

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
