### PR TITLE
Reduce the number of af_xdp tests

### DIFF
--- a/examples/afxdp/README.md
+++ b/examples/afxdp/README.md
@@ -18,10 +18,6 @@ If the packet belongs to the NSM interface it forwards it to the VPP, otherwise 
 
 ## Includes
 
-- [Memif to Memif Connection](../use-cases/Memif2Memif)
-- [Kernel to Kernel Connection](../use-cases/Kernel2Kernel)
-- [Kernel to Memif Connection](../use-cases/Kernel2Memif)
-- [Memif to Kernel Connection](../use-cases/Memif2Kernel)
 - [Kernel to Ethernet to Kernel Connection](../use-cases/Kernel2Ethernet2Kernel)
 - [Memif to Ethernet to Memif Connection](../use-cases/Memif2Ethernet2Memif)
 - [Kernel to Ethernet to Memif Connection](../use-cases/Kernel2Ethernet2Memif)
@@ -30,27 +26,8 @@ If the packet belongs to the NSM interface it forwards it to the VPP, otherwise 
 - [Memif to IP to Memif Connection](../use-cases/Memif2IP2Memif)
 - [Kernel to IP to Memif Connection](../use-cases/Kernel2IP2Memif)
 - [Memif to IP to Kernel Connection](../use-cases/Memif2IP2Kernel)
-- [Simple OPA example](../features/opa)
-- [Kernel2Kernel IPv6 example](../features/ipv6/Kernel2Kernel_ipv6)
-- [Memif2Memif IPv6 example](../features/ipv6/Memif2Memif_ipv6)
 - [Kernel2IP2Kernel IPv6 example](../features/ipv6/Kernel2IP2Kernel_ipv6)
-- [Kernel2IP2Memif IPv6 example](../features/ipv6/Kernel2IP2Memif_ipv6)
-- [Memif2IP2Kernel IPv6 example](../features/ipv6/Memif2IP2Kernel_ipv6)
 - [Memif2IP2Memif IPv6 example](../features/ipv6/Memif2IP2Memif_ipv6)
-- [Kernel2Kernel dual stack example](../features/dual-stack/Kernel2Kernel_dual_stack)
-- [Kernel2IP2Kernel dual stack example](../features/dual-stack/Kernel2IP2Kernel_dual_stack)
-- [Admission webhook](../features/webhook)
-- [DNS](../features/dns)
-- [Topology aware scale from zero](../features/scale-from-zero)
-- [NSE composition](../features/nse-composition)
-- [Exclude prefixes](../features/exclude-prefixes)
-- [Exclude prefixes client](../features/exclude-prefixes-client)
-- [Policy based routing](../features/policy-based-routing)
-- [Mutually aware NSEs](../features/mutually-aware-nses)
-- [vL3-basic](../features/vl3-basic)
-- [vL3 DNS](../features/vl3-dns)
-- [vL3-scale-from-zero](../features/vl3-scale-from-zero)
-- [Inject clients in namespace via NSM annotation](../features/annotated-namespace)
 
 ## Run
 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
So many tests don't make sense, it just wastes time. AF_XDP only affects remote cases.

This PR will allow us to run tests on public clusters without increasing the time too much.

I left here only remote cases, as well as a few examples from features.

## Issue link
https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/859
https://github.com/networkservicemesh/integration-k8s-gke/issues/383


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
