### PR TITLE
Optimize the loadbalacer usage for examples

### DIFF
--- a/apps/admission-webhook-k8s/service.yaml
+++ b/apps/admission-webhook-k8s/service.yaml
@@ -11,3 +11,4 @@ spec:
       targetPort: 443
   selector:
     app: admission-webhook-k8s
+  type: ClusterIP

--- a/apps/registry-k8s/registry-service.yaml
+++ b/apps/registry-k8s/registry-service.yaml
@@ -11,4 +11,4 @@ spec:
       protocol: TCP
       port: 5002
       targetPort: 5002
-  type: LoadBalancer
+  type: ClusterIP

--- a/apps/registry-memory/registry-service.yaml
+++ b/apps/registry-memory/registry-service.yaml
@@ -11,4 +11,4 @@ spec:
       protocol: TCP
       port: 5002
       targetPort: 5002
-  type: LoadBalancer
+  type: ClusterIP

--- a/apps/registry-proxy-dns/registry-proxy-service.yaml
+++ b/apps/registry-proxy-dns/registry-proxy-service.yaml
@@ -10,3 +10,4 @@ spec:
     - protocol: TCP
       port: 5005
       targetPort: 5005
+  type: ClusterIP

--- a/apps/vl3-ipam/vl3-ipam-service.yaml
+++ b/apps/vl3-ipam/vl3-ipam-service.yaml
@@ -11,4 +11,4 @@ spec:
       protocol: TCP
       port: 5006
       targetPort: 5006
-  type: LoadBalancer
+  type: ClusterIP

--- a/examples/multicluster/clusters-configuration/cluster1/kustomization.yaml
+++ b/examples/multicluster/clusters-configuration/cluster1/kustomization.yaml
@@ -20,3 +20,10 @@ patchesStrategicMerge:
 - patch-nsmgr-proxy.yaml
 - patch-registry-proxy-dns.yaml
 - patch-registry-memory.yaml
+
+patches:
+ - target:
+      version: v1
+      kind: Service
+      name: registry
+   path: patch-registry-service.yaml

--- a/examples/multicluster/clusters-configuration/cluster1/patch-registry-service.yaml
+++ b/examples/multicluster/clusters-configuration/cluster1/patch-registry-service.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/type
+  value: LoadBalancer

--- a/examples/multicluster/clusters-configuration/cluster2/kustomization.yaml
+++ b/examples/multicluster/clusters-configuration/cluster2/kustomization.yaml
@@ -20,3 +20,10 @@ patchesStrategicMerge:
 - patch-nsmgr-proxy.yaml
 - patch-registry-proxy-dns.yaml
 - patch-registry-memory.yaml
+
+patches:
+ - target:
+      version: v1
+      kind: Service
+      name: registry
+   path: patch-registry-service.yaml

--- a/examples/multicluster/clusters-configuration/cluster2/patch-registry-service.yaml
+++ b/examples/multicluster/clusters-configuration/cluster2/patch-registry-service.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/type
+  value: LoadBalancer

--- a/examples/multicluster/clusters-configuration/cluster3/kustomization.yaml
+++ b/examples/multicluster/clusters-configuration/cluster3/kustomization.yaml
@@ -10,3 +10,10 @@ resources:
 
 patchesStrategicMerge:
 - patch-registry-k8s.yaml
+
+patches:
+ - target:
+      version: v1
+      kind: Service
+      name: registry
+   path: patch-registry-service.yaml

--- a/examples/multicluster/clusters-configuration/cluster3/patch-registry-service.yaml
+++ b/examples/multicluster/clusters-configuration/cluster3/patch-registry-service.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/type
+  value: LoadBalancer

--- a/examples/spire/base/server-service.yaml
+++ b/examples/spire/base/server-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spire-server
   namespace: spire
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - name: spire-server
       port: 8081
@@ -26,3 +26,4 @@ spec:
       targetPort: 9443
   selector:
     app: spire-server
+  type: ClusterIP

--- a/examples/spire/cluster1/kustomization.yaml
+++ b/examples/spire/cluster1/kustomization.yaml
@@ -10,6 +10,13 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 
+patches:
+ - target:
+      version: v1
+      kind: Service
+      name: spire-server
+   path: service-patch.yaml
+
 configMapGenerator:
 - name: spire-server
   namespace: spire

--- a/examples/spire/cluster1/service-patch.yaml
+++ b/examples/spire/cluster1/service-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/type
+  value: LoadBalancer

--- a/examples/spire/cluster2/kustomization.yaml
+++ b/examples/spire/cluster2/kustomization.yaml
@@ -23,3 +23,10 @@ configMapGenerator:
   namespace: spire
   files:
   - spire-controller-manager-config.yaml
+
+patches:
+ - target:
+      version: v1
+      kind: Service
+      name: spire-server
+   path: service-patch.yaml

--- a/examples/spire/cluster2/service-patch.yaml
+++ b/examples/spire/cluster2/service-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/type
+  value: LoadBalancer

--- a/examples/spire/cluster3/kustomization.yaml
+++ b/examples/spire/cluster3/kustomization.yaml
@@ -23,3 +23,10 @@ configMapGenerator:
   namespace: spire
   files:
   - spire-controller-manager-config.yaml
+
+patches:
+ - target:
+      version: v1
+      kind: Service
+      name: spire-server
+   path: service-patch.yaml

--- a/examples/spire/cluster3/service-patch.yaml
+++ b/examples/spire/cluster3/service-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/type
+  value: LoadBalancer


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Currently, testing with single cluster public clusters could affect interdomain testing because we're using loadbalancer services (cluster provider will allocate load banacer server for singlecluster and for interdomain when we don't need loadbalancers for single cluster testing).


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
