### PR TITLE
Update examples/basic/README.md

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -36,6 +36,25 @@ WH=$(kubectl get pods -l app=admission-webhook-k8s -n nsm-system --template '{{r
 kubectl wait --for=condition=ready --timeout=1m pod ${WH} -n nsm-system
 ```
 
+Wait for nsmgr:
+
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=nsmgr -n nsm-system
+```
+
+Wait for forwarder-vpp:
+
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=forwarder-vpp -n nsm-system
+```
+
+Wait for registry-k8s:
+
+```bash
+RG=$(kubectl get pods -l app=registry -n nsm-system --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+kubectl wait --for=condition=ready --timeout=1m pod ${RG} -n nsm-system
+```
+
 ## Cleanup
 
 To free resources follow the next commands:


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Existing README doesn't suggest waiting until all pods become running
The pull request provides additional steps in the instruction
But I have a doubt about the naming of the pod **registry-k8s**
The pod  **registry-k8s** has the label `app=registry`, but the pod **admission-webhook-k8s** has the label `app=admission-webhook-k8s`
## Issue link
No


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [x] Documentation
- [ ] Refactoring
- [ ] CI
