### PR TITLE
Task 292 Feature Request: Allow configuration of initContainer resource requests and limits

### DIFF
--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: admission-webhook-sa
       containers:
         - name: admission-webhook-k8s
-          image: to-do-replace-this-image-with-actual
+          image: ghcr.io/networkservicemesh/ci/cmd-admission-webhook-k8s:8ba6122
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
@@ -47,11 +47,19 @@ spec:
               value: spiffe.io/spiffe-id:true
             - name: NSM_ENVS
               value: NSM_LOG_LEVEL=TRACE
-            - name: NSM_RESOURCES_LIMITS_MEMORY
+            - name: NSM_NSC_INIT_LIMITS_MEMORY
+              value: 80Mi
+            - name: NSM_NSC_INIT_REQUESTS_MEMORY
               value: 40Mi
-            - name: NSM_RESOURCES_REQUESTS_MEMORY
-              value: 40Mi
-            - name: NSM_RESOURCES_LIMITS_CPU
+            - name: NSM_NSC_INIT_LIMITS_CPU
+              value: 200m
+            - name: NSM_NSC_INIT_REQUESTS_CPU
               value: 100m
-            - name: NSM_RESOURCES_REQUESTS_CPU
+            - name: NSM_NSC_LIMITS_MEMORY
+              value: 80Mi
+            - name: NSM_NSC_REQUESTS_MEMORY
+              value: 40Mi
+            - name: NSM_NSC_LIMITS_CPU
+              value: 200m
+            - name: NSM_NSC_REQUESTS_CPU
               value: 100m

--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -55,11 +55,3 @@ spec:
               value: 200m
             - name: NSM_SIDECAR_REQUESTS_CPU
               value: 100m
-            - name: NSM_CONTAINER_LIMITS_MEMORY
-              value: 80Mi
-            - name: NSM_CONTAINER_REQUESTS_MEMORY
-              value: 40Mi
-            - name: NSM_CONTAINER_LIMITS_CPU
-              value: 200m
-            - name: NSM_CONTAINER_REQUESTS_CPU
-              value: 100m

--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: admission-webhook-sa
       containers:
         - name: admission-webhook-k8s
-          image: ghcr.io/networkservicemesh/ci/cmd-admission-webhook-k8s:8ba6122
+          image: to-do-replace-this-image-with-actual
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
@@ -47,3 +47,11 @@ spec:
               value: spiffe.io/spiffe-id:true
             - name: NSM_ENVS
               value: NSM_LOG_LEVEL=TRACE
+            - name: NSM_RESOURCES_LIMITS_MEMORY
+              value: 40Mi
+            - name: NSM_RESOURCES_REQUESTS_MEMORY
+              value: 40Mi
+            - name: NSM_RESOURCES_LIMITS_CPU
+              value: 100m
+            - name: NSM_RESOURCES_REQUESTS_CPU
+              value: 100m

--- a/apps/admission-webhook-k8s/admission-webhook.yaml
+++ b/apps/admission-webhook-k8s/admission-webhook.yaml
@@ -47,19 +47,19 @@ spec:
               value: spiffe.io/spiffe-id:true
             - name: NSM_ENVS
               value: NSM_LOG_LEVEL=TRACE
-            - name: NSM_NSC_INIT_LIMITS_MEMORY
+            - name: NSM_SIDECAR_LIMITS_MEMORY
               value: 80Mi
-            - name: NSM_NSC_INIT_REQUESTS_MEMORY
+            - name: NSM_SIDECAR_REQUESTS_MEMORY
               value: 40Mi
-            - name: NSM_NSC_INIT_LIMITS_CPU
+            - name: NSM_SIDECAR_LIMITS_CPU
               value: 200m
-            - name: NSM_NSC_INIT_REQUESTS_CPU
+            - name: NSM_SIDECAR_REQUESTS_CPU
               value: 100m
-            - name: NSM_NSC_LIMITS_MEMORY
+            - name: NSM_CONTAINER_LIMITS_MEMORY
               value: 80Mi
-            - name: NSM_NSC_REQUESTS_MEMORY
+            - name: NSM_CONTAINER_REQUESTS_MEMORY
               value: 40Mi
-            - name: NSM_NSC_LIMITS_CPU
+            - name: NSM_CONTAINER_LIMITS_CPU
               value: 200m
-            - name: NSM_NSC_REQUESTS_CPU
+            - name: NSM_CONTAINER_REQUESTS_CPU
               value: 100m


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Allow configuration of initContainer resource requests and limits
Prerequisite PR in `cmd-admission-webhook-k8s`: https://github.com/networkservicemesh/cmd-admission-webhook-k8s/pull/321

As I can see image `admission-webhook-k8s` is updated after merge prerequisite PR https://github.com/networkservicemesh/deployments-k8s/pull/9728/files, so we can merge this changes

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/cmd-admission-webhook-k8s/issues/292


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
