### PR TITLE
Disable tunnel IP override in forwarder-vpp

### DIFF
--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -29,10 +29,6 @@ spec:
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_LOG_LEVEL
               value: TRACE
-            - name: NSM_TUNNEL_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
             - name: NSM_CONNECT_TO
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_LISTEN_ON

--- a/examples/basic/forwarder-patch.yaml
+++ b/examples/basic/forwarder-patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: forwarder-vpp
+spec:
+  selector: {}
+  template:
+    spec:
+      containers:
+      - name: forwarder-vpp
+        env:
+        # Usually forwarder finds tunnel IP automatically.
+        # Here we effectively set it to node Internal IP because in basic (single-cluster) setup
+        # we are guaranteed to have connectivity between cluster nodes using this IP.
+        - name: NSM_TUNNEL_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP

--- a/examples/basic/kustomization.yaml
+++ b/examples/basic/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 - ../../apps/forwarder-vpp
 - ../../apps/registry-k8s
 - ../../apps/admission-webhook-k8s
+
+patches:
+- path: forwarder-patch.yaml

--- a/examples/features/select-forwarder/forwarder.yaml
+++ b/examples/features/select-forwarder/forwarder.yaml
@@ -29,6 +29,10 @@ spec:
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_LOG_LEVEL
               value: TRACE
+            - name: NSM_TUNNEL_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NSM_CONNECT_TO
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_LISTEN_ON

--- a/examples/features/select-forwarder/forwarder.yaml
+++ b/examples/features/select-forwarder/forwarder.yaml
@@ -29,10 +29,6 @@ spec:
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_LOG_LEVEL
               value: TRACE
-            - name: NSM_TUNNEL_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
             - name: NSM_CONNECT_TO
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_LISTEN_ON


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

`forwarder-vpp` has config variable `NSM_TUNNEL_IP` which is currently used to determine the interface the forwarder will use for data plane connection.
When `NSM_TUNNEL_IP` is not set, `forwarder-vpp` automatically selects default interface instead (interface with default route). `NSM_TUNNEL_IP` was intended to be used to override this behavior in case you want to use a different interface.
We actually want to use the default interface instead of setting `NSM_TUNNEL_IP` manually.

## Issue link
<!--- Please link to the issue here. -->

https://github.com/networkservicemesh/deployments-k8s/issues/10021

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
