### PR TITLE
[quick fix] Remove hostport from apps

### DIFF
--- a/apps/nsmgr-proxy/nsmgr-proxy.yaml
+++ b/apps/nsmgr-proxy/nsmgr-proxy.yaml
@@ -22,7 +22,6 @@ spec:
           name: nsmgr-proxy
           ports:
             - containerPort: 5004
-              hostPort: 5004
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -22,7 +22,6 @@ spec:
           name: nsmgr
           ports:
             - containerPort: 5001
-              hostPort: 5001
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -35,7 +35,6 @@ spec:
           name: registry
           ports:
             - containerPort: 5002
-              hostPort: 5002
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/registry-memory/registry-memory.yaml
+++ b/apps/registry-memory/registry-memory.yaml
@@ -30,7 +30,6 @@ spec:
           name: registry
           ports:
             - containerPort: 5002
-              hostPort: 5002
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/registry-proxy-dns/registry-proxy-dns.yaml
+++ b/apps/registry-proxy-dns/registry-proxy-dns.yaml
@@ -28,7 +28,6 @@ spec:
           name: registry
           ports:
             - containerPort: 5005
-              hostPort: 5005
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/vl3-ipam/vl3-ipam.yaml
+++ b/apps/vl3-ipam/vl3-ipam.yaml
@@ -30,7 +30,6 @@ spec:
           name: vl3-ipam
           ports:
             - containerPort: 5006
-              hostPort: 5006
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/examples/interdomain/nsm_consul_vl3/cluster1/vl3-ipam/vl3-ipam.yaml
+++ b/examples/interdomain/nsm_consul_vl3/cluster1/vl3-ipam/vl3-ipam.yaml
@@ -30,7 +30,6 @@ spec:
           name: vl3-ipam
           ports:
             - containerPort: 5006
-              hostPort: 5006
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Currently many of our core apps declare host ports. However, we don't need host ports, we use LoadBalancer type services when we need external connectivity.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
