### PR TITLE
Revert host port changes

### DIFF
--- a/apps/nsmgr-proxy/nsmgr-proxy.yaml
+++ b/apps/nsmgr-proxy/nsmgr-proxy.yaml
@@ -22,6 +22,7 @@ spec:
           name: nsmgr-proxy
           ports:
             - containerPort: 5004
+              hostPort: 5004
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -22,6 +22,7 @@ spec:
           name: nsmgr
           ports:
             - containerPort: 5001
+              hostPort: 5001
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -35,6 +35,7 @@ spec:
           name: registry
           ports:
             - containerPort: 5002
+              hostPort: 5002
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/registry-memory/registry-memory.yaml
+++ b/apps/registry-memory/registry-memory.yaml
@@ -30,6 +30,7 @@ spec:
           name: registry
           ports:
             - containerPort: 5002
+              hostPort: 5002
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/registry-proxy-dns/registry-proxy-dns.yaml
+++ b/apps/registry-proxy-dns/registry-proxy-dns.yaml
@@ -28,6 +28,7 @@ spec:
           name: registry
           ports:
             - containerPort: 5005
+              hostPort: 5005
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/vl3-ipam/vl3-ipam.yaml
+++ b/apps/vl3-ipam/vl3-ipam.yaml
@@ -30,6 +30,7 @@ spec:
           name: vl3-ipam
           ports:
             - containerPort: 5006
+              hostPort: 5006
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/examples/interdomain/nsm_consul_vl3/cluster1/vl3-ipam/vl3-ipam.yaml
+++ b/examples/interdomain/nsm_consul_vl3/cluster1/vl3-ipam/vl3-ipam.yaml
@@ -30,6 +30,7 @@ spec:
           name: vl3-ipam
           ports:
             - containerPort: 5006
+              hostPort: 5006
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets


### PR DESCRIPTION
This reverts commit 3ebf1bf0881f6851d205b863d97bd3ff32bce9f7.

Issue: https://github.com/networkservicemesh/deployments-k8s/issues/10021

This PR should theoretically fix interdomain tests here: https://github.com/networkservicemesh/integration-k8s-kind/pull/903