### PR TITLE
Add volumeClaimTemplates to the spire-server statefulset

### DIFF
--- a/examples/heal/spire-server-restart/README.md
+++ b/examples/heal/spire-server-restart/README.md
@@ -57,20 +57,6 @@ Ping from NSE to NSC:
 kubectl exec deployments/nse-kernel -n ns-spire-server-restart -- ping -c 4 172.16.1.101
 ```
 
-Find SPIRE Agents:
-```bash
-AGENTS=$(kubectl get pods -l app=spire-agent -n spire --template '{{range .items}}{{.metadata.name}}{{" "}}{{end}}')
-```
-
-Back to initial state, restart SPIRE agents and wait for them to start:
-```bash
-kubectl delete pod $AGENTS -n spire
-```
-
-```bash
-kubectl wait --for=condition=ready --timeout=1m pod -l app=spire-agent -n spire
-```
-
 ## Cleanup
 
 Delete ns:

--- a/examples/spire/base/server-statefulset.yaml
+++ b/examples/spire/base/server-statefulset.yaml
@@ -34,6 +34,9 @@ spec:
               readOnly: true
             - name: spire-server-socket
               mountPath: /tmp/spire-server/private
+            - name: spire-data
+              mountPath: /run/spire/data
+              readOnly: false
           livenessProbe:
             exec:
               command:
@@ -69,3 +72,13 @@ spec:
         - name: spire-controller-manager-config
           configMap:
             name: spire-controller-manager-config
+  volumeClaimTemplates:
+    - metadata:
+        name: spire-data
+        namespace: spire
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description

Spire-server requires `PersistentVolume` for `/run/spire/data`.
Apparently, if the server is restarted, this data is used to issue the correct certificates.
If we don't use the PersistentVolume, then _new_ and _old_ certificates are not compatible with each other.

See manuals:
> If you are using Kubeadm to run this tutorial, a default storage class and an associated provisioner must be manually created, otherwise the spire-server pod will stay in Pending status, showing the 1 pod has unbound immediate PersistentVolumeClaims error. 
https://spiffe.io/docs/latest/try/getting-started-k8s/#overview

Example:
https://github.com/spiffe/spire-tutorials/blob/main/k8s/quickstart/server-statefulset.yaml#L54-L63

## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/10286


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
