### PR TITLE
[qfix] Add a label to Spire namespace

### DIFF
--- a/apps/admission-webhook-k8s/mutating-webhook-config.yaml
+++ b/apps/admission-webhook-k8s/mutating-webhook-config.yaml
@@ -25,6 +25,10 @@ webhooks:
       - kube-system
       - spire
       - nsm-system
+    - key: name
+      operator: NotIn
+      values:
+      - spire
   objectSelector: {}
   reinvocationPolicy: Never
   rules:

--- a/examples/spire/base/spire-namespace.yaml
+++ b/examples/spire/base/spire-namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: spire
+  labels:
+    name: spire


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
In k8s v1.20.15 Namespaces don't have predefined labels. Webhook can't exclude them because it can't find them using predefinded labels. Adding a label to Spire namespace should fix the problem.

## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/7112110581/job/19361413276?pr=927


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
