### PR TITLE
Increase spire-server wait

### DIFF
--- a/examples/features/jaeger/README.md
+++ b/examples/features/jaeger/README.md
@@ -104,10 +104,10 @@ kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/
 
 Wait for Spire pods status ready:
 ```bash
-kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent
+kubectl wait -n spire --timeout=3m --for=condition=ready pod -l app=spire-server
 ```
 ```bash
-kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
+kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent
 ```
 
 Create namespace nsm-system:

--- a/examples/heal/spire-server-agent-restart/README.md
+++ b/examples/heal/spire-server-agent-restart/README.md
@@ -50,7 +50,7 @@ kubectl delete pod spire-server-0 -n spire
 ```
 
 ```bash
-kubectl wait --for=condition=ready --timeout=1m pod -l app=spire-server -n spire
+kubectl wait --for=condition=ready --timeout=3m pod -l app=spire-server -n spire
 ```
 
 Restart SPIRE agents and wait for them to start:

--- a/examples/heal/spire-server-restart/README.md
+++ b/examples/heal/spire-server-restart/README.md
@@ -44,7 +44,7 @@ Restart SPIRE server and wait for it to start:
 kubectl delete pod spire-server-0 -n spire
 ```
 ```bash
-kubectl wait --for=condition=ready --timeout=1m pod -l app=spire-server -n spire
+kubectl wait --for=condition=ready --timeout=3m pod -l app=spire-server -n spire
 ```
 
 Ping from NSC to NSE:

--- a/examples/heal/spire-upgrade/README.md
+++ b/examples/heal/spire-upgrade/README.md
@@ -53,7 +53,7 @@ kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/
 ```
 
 ```bash
-kubectl wait --for=condition=ready --timeout=1m pod -l app=spire-server -n spire
+kubectl wait --for=condition=ready --timeout=3m pod -l app=spire-server -n spire
 ```
 ```bash
 kubectl wait --for=condition=ready --timeout=1m pod -l app=spire-agent -n spire

--- a/examples/spire/cluster1/README.md
+++ b/examples/spire/cluster1/README.md
@@ -19,7 +19,7 @@ kubectl --kubeconfig=$KUBECONFIG1 apply -k https://github.com/networkservicemesh
 
 Wait for PODs status ready:
 ```bash
-kubectl --kubeconfig=$KUBECONFIG1 wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
+kubectl --kubeconfig=$KUBECONFIG1 wait -n spire --timeout=3m --for=condition=ready pod -l app=spire-server
 ```
 ```bash
 kubectl --kubeconfig=$KUBECONFIG1 wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent

--- a/examples/spire/cluster2/README.md
+++ b/examples/spire/cluster2/README.md
@@ -19,7 +19,7 @@ kubectl --kubeconfig=$KUBECONFIG2 apply -k https://github.com/networkservicemesh
 
 Wait for PODs status ready:
 ```bash
-kubectl --kubeconfig=$KUBECONFIG2 wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
+kubectl --kubeconfig=$KUBECONFIG2 wait -n spire --timeout=3m --for=condition=ready pod -l app=spire-server
 ```
 ```bash
 kubectl --kubeconfig=$KUBECONFIG2 wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent

--- a/examples/spire/cluster3/README.md
+++ b/examples/spire/cluster3/README.md
@@ -19,7 +19,7 @@ kubectl --kubeconfig=$KUBECONFIG3 apply -k https://github.com/networkservicemesh
 
 Wait for PODs status ready:
 ```bash
-kubectl --kubeconfig=$KUBECONFIG3 wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
+kubectl --kubeconfig=$KUBECONFIG3 wait -n spire --timeout=3m --for=condition=ready pod -l app=spire-server
 ```
 ```bash
 kubectl --kubeconfig=$KUBECONFIG3 wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent

--- a/examples/spire/single_cluster/README.md
+++ b/examples/spire/single_cluster/README.md
@@ -11,7 +11,7 @@ kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/
 
 Wait for PODs status ready:
 ```bash
-kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
+kubectl wait -n spire --timeout=3m --for=condition=ready pod -l app=spire-server
 ```
 ```bash
 kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent

--- a/examples/spire/single_cluster_csi/README.md
+++ b/examples/spire/single_cluster_csi/README.md
@@ -11,7 +11,7 @@ kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/
 
 Wait for PODs status ready:
 ```bash
-kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
+kubectl wait -n spire --timeout=3m --for=condition=ready pod -l app=spire-server
 ```
 ```bash
 kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-agent


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Attaching a volume sometimes takes time:
```
  Normal  Scheduled               57s   default-scheduler        Successfully assigned spire/spire-server-0 to aks-nodepool1-24896710-vmss000001
  Normal  SuccessfulAttachVolume  0s    attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-3c0c4cc6-87fb-46fd-a7cc-1c2085bb56f2" TestRunBasicSuite=stdout
```

## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/10286


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
