### PR TITLE
Heal extended test: component restarts

### DIFF
--- a/examples/heal_extended/README.md
+++ b/examples/heal_extended/README.md
@@ -1,0 +1,12 @@
+# Extended heal examples
+
+This document contains links for extended heal examples of NSM.
+Unlike standard heal tests, these tests are more aggressive and require more execution time.
+
+## Requires
+
+To run any heal example follow steps for [Basic NSM setup](../basic)
+
+## Includes
+
+ - [Component restart](./component-restart)

--- a/examples/heal_extended/component-restart/README.md
+++ b/examples/heal_extended/component-restart/README.md
@@ -1,0 +1,124 @@
+# NSM component restarts
+
+This example shows that NSM keeps working after NSM components restarts several times.
+We deploy two clients - one of them supports only Control Plane-based healing (client-cp), the other supports full healing (client).
+Please note that for convenience, this example doesn't use NSM annotations, but instead deploys bare NSC applications.
+
+NSCs and NSE are using the `kernel` mechanism to connect to its local forwarder.
+Forwarders are using the `vxlan` mechanism to connect with each other.
+
+## Requires
+
+Make sure that you have completed steps from [basic](../../basic) setup.
+
+## Run
+
+Deploy NSCs and NSE:
+```bash
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/heal_extended/component-restart?ref=9eca122e964b8fedf1cbd57a5c8330b9bb8ca7a7
+```
+
+Wait for applications ready:
+```bash
+kubectl wait --for=condition=ready --timeout=1m pod -l app=client -n ns-component-restart
+```
+
+Define env variables for scripts:
+```bash
+# N_RESTARTS - number of restarts
+# TEST_TIME - determines how long the test will take (sec)
+# DELAY - delay between restarts (sec)
+# INTERFACE_READY_WAIT - how long do we wait for the interface to be ready (sec). Equals to NSM_REQUEST_TIMEOUT * 2 (for Close and Request)
+N_RESTARTS=15
+TEST_TIME=900
+DELAY=$(($TEST_TIME/$N_RESTARTS))
+INTERFACE_READY_WAIT=10
+```
+
+Test functions:
+```bash
+# Iterates over NSCs and checks connectivity to NSE (sends pings)
+function connectivity_check() {
+echo -e "\n-- Connectivity check --"
+nscs=$(kubectl  get pods -l app=client -o go-template --template="{{range .items}}{{.metadata.name}} {{end}}" -n ns-component-restart)
+for nsc in $nscs
+do
+    echo -e "\nNSC: $nsc"
+    echo "Wait for NSM interface to be ready"
+    for i in $(seq 1 $INTERFACE_READY_WAIT)
+    do
+        if [ $i -eq $INTERFACE_READY_WAIT ] ; then
+          echo "NSM interface is not ready after $INTERFACE_READY_WAIT s"
+          return 1
+        fi
+        sleep 1
+        routes=$(kubectl exec -n ns-component-restart $nsc -- ip route)
+        nseAddr=$(echo $routes | grep -Eo '172\.16\.1\.[0-9]{1,3}')
+        test $? -ne 0 || break
+    done
+    echo "NSM interface is ready"
+    kubectl exec $nsc -n ns-component-restart -- ping -c2 -i 0.5 $nseAddr || return 2
+done
+return 0
+}
+
+# Restarts NSM components and checks connectivity.
+# $1 is used to define NSM-component type (e.g. forwarder or nsmgr)
+# -a defines the restart method.
+#   if specified - all NSM-pods of this type will be restarted at the same time.
+#   else - they will be restarted one by one.
+function restart_nsm_component() {
+nsm_component=$1
+shift
+
+a_flag=0
+while getopts 'a' flag; do
+  case "${flag}" in
+    a) a_flag=1 ;;
+  esac
+done
+
+for i in $(seq 1 $N_RESTARTS)
+do
+    echo -e "\n-------- $nsm_component restart $i of $N_RESTARTS --------"
+    echo "Wait $DELAY sec before restart..."
+    sleep $DELAY
+    if [ $a_flag -eq 1 ]; then
+        kubectl delete pod -n nsm-system -l app=${nsm_component}
+        kubectl wait --for=condition=ready --timeout=1m pod -l app=${nsm_component} -n nsm-system || return 1
+        connectivity_check || return 2
+    else
+        nodes=$(kubectl get pods -l app=${nsm_component} -n nsm-system --template '{{range .items}}{{.spec.nodeName}}{{"\n"}}{{end}}')
+        for node in $nodes
+        do
+            kubectl delete pod -n nsm-system -l app=${nsm_component} --field-selector spec.nodeName==${node}
+            kubectl wait --for=condition=ready --timeout=1m pod -l app=${nsm_component} --field-selector spec.nodeName==${node} -n nsm-system || return 1
+            connectivity_check || return 2
+        done
+    fi
+done
+return 0
+}
+```
+
+Check the connection before restarts:
+```bash
+connectivity_check
+```
+
+Restart forwarders one by one:
+```bash
+restart_nsm_component forwarder-vpp
+```
+
+Restart all forwarders at the same time:
+```bash
+restart_nsm_component forwarder-vpp -a
+```
+
+## Cleanup
+
+Delete ns:
+```bash
+kubectl delete ns ns-component-restart
+```

--- a/examples/heal_extended/component-restart/README.md
+++ b/examples/heal_extended/component-restart/README.md
@@ -15,7 +15,7 @@ Make sure that you have completed steps from [basic](../../basic) setup.
 
 Deploy NSCs and NSE:
 ```bash
-kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/heal_extended/component-restart?ref=9eca122e964b8fedf1cbd57a5c8330b9bb8ca7a7
+kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/heal_extended/component-restart?ref=a3fd4926f681e237f662352ec2578d5ec04f38ea
 ```
 
 Wait for applications ready:

--- a/examples/heal_extended/component-restart/client-cp.yaml
+++ b/examples/heal_extended/component-restart/client-cp.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: client-cp
+  labels:
+    app: client
+    spiffe.io/spiffe-id: "true"
+spec:
+  containers:
+    - name: nsc
+      image: ghcr.io/networkservicemesh/ci/cmd-nsc:cfc2107
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: SPIFFE_ENDPOINT_SOCKET
+          value: unix:///run/spire/sockets/agent.sock
+        - name: NSM_LOG_LEVEL
+          value: TRACE
+        - name: NSM_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NSM_NETWORK_SERVICES
+          value: kernel://component-restart/nsm-1
+        - name: NSM_MAX_TOKEN_LIFETIME
+          value: "2m"
+        - name: NSM_REQUEST_TIMEOUT
+          value: "5s"
+        - name: NSM_LIVENESSCHECKENABLED
+          value: "false"
+      volumeMounts:
+        - name: spire-agent-socket
+          mountPath: /run/spire/sockets
+          readOnly: true
+        - name: nsm-socket
+          mountPath: /var/lib/networkservicemesh
+          readOnly: true
+      resources:
+        limits:
+          memory: 80Mi
+          cpu: 200m
+  volumes:
+    - name: spire-agent-socket
+      hostPath:
+        path: /run/spire/sockets
+        type: Directory
+    - name: nsm-socket
+      hostPath:
+        path: /var/lib/networkservicemesh
+        type: DirectoryOrCreate
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - client
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - nse-kernel

--- a/examples/heal_extended/component-restart/client.yaml
+++ b/examples/heal_extended/component-restart/client.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: client
+  labels:
+    app: client
+    spiffe.io/spiffe-id: "true"
+spec:
+  containers:
+    - name: nsc
+      image: ghcr.io/networkservicemesh/ci/cmd-nsc:cfc2107
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: SPIFFE_ENDPOINT_SOCKET
+          value: unix:///run/spire/sockets/agent.sock
+        - name: NSM_LOG_LEVEL
+          value: TRACE
+        - name: NSM_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NSM_NETWORK_SERVICES
+          value: kernel://component-restart/nsm-1
+        - name: NSM_MAX_TOKEN_LIFETIME
+          value: "2m"
+        - name: NSM_REQUEST_TIMEOUT
+          value: "5s"
+      volumeMounts:
+        - name: spire-agent-socket
+          mountPath: /run/spire/sockets
+          readOnly: true
+        - name: nsm-socket
+          mountPath: /var/lib/networkservicemesh
+          readOnly: true
+      resources:
+        limits:
+          memory: 80Mi
+          cpu: 200m
+  volumes:
+    - name: spire-agent-socket
+      hostPath:
+        path: /run/spire/sockets
+        type: Directory
+    - name: nsm-socket
+      hostPath:
+        path: /var/lib/networkservicemesh
+        type: DirectoryOrCreate
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - client
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - nse-kernel

--- a/examples/heal_extended/component-restart/kustomization.yaml
+++ b/examples/heal_extended/component-restart/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ns-component-restart
+
+resources:
+- ns-component-restart.yaml
+- netsvc.yaml
+- client.yaml
+- client-cp.yaml
+- ../../../apps/nse-kernel
+
+patchesStrategicMerge:
+- patch-nse.yaml

--- a/examples/heal_extended/component-restart/netsvc.yaml
+++ b/examples/heal_extended/component-restart/netsvc.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: networkservicemesh.io/v1
+kind: NetworkService
+metadata:
+  name: component-restart
+spec:
+  payload: ETHERNET

--- a/examples/heal_extended/component-restart/ns-component-restart.yaml
+++ b/examples/heal_extended/component-restart/ns-component-restart.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-component-restart

--- a/examples/heal_extended/component-restart/patch-nse.yaml
+++ b/examples/heal_extended/component-restart/patch-nse.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+spec:
+  template:
+    spec:
+      containers:
+        - name: nse
+          env:
+            - name: NSM_CIDR_PREFIX
+              value: 172.16.1.100/30
+            - name: NSM_SERVICE_NAMES
+              value: "component-restart"
+            - name: NSM_REGISTER_SERVICE
+              value: "false"


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Unlike standard heal tests, these tests are more aggressive and require more execution time

**Test Component Restart**
(takes about 45 min on kind cluster)
Restarts the NSM component several times in different modes - all instances or one by one. The current PR contains only the Forwarder check, but can be extended to NSMgr.

## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/10918


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
