### PR TITLE
Fix monolith docker dns

### DIFF
--- a/examples/k8s_monolith/external_nsc/dns/README.md
+++ b/examples/k8s_monolith/external_nsc/dns/README.md
@@ -87,13 +87,13 @@ kubectl rollout restart -n kube-system deployment/coredns
 
 Save the initial `resolv.conf` in a separate file:
 ```bash
-docker exec -d -i nsc-simple-docker cp /etc/resolv.conf /etc/resolv_init.conf
+docker exec nsc-simple-docker cp /etc/resolv.conf /etc/resolv_init.conf
 ```
 
 Add an entry to `resolv.conf` with a coredns address.
 Use a custom address to reduce the chance of it being used (default is 127.0.0.1)
 ```bash
-docker exec -d -i nsc-simple-docker sh -c "echo 'nameserver 127.0.1.1' > /etc/resolv.conf"
+docker exec nsc-simple-docker sh -c "echo 'nameserver 127.0.1.1' > /etc/resolv.conf"
 ```
 
 Create coredns config file:
@@ -104,12 +104,17 @@ cat > coredns-config << EOF
     log
     errors
     ready
-    file dnsentries.db
     forward . /etc/resolv_init.conf {
         max_concurrent 1000
     }
     loop
     reload 5s
+}
+docker.nsm:53 {
+    bind 127.0.1.1
+    log
+    errors
+    file dnsentries.db
 }
 k8s.nsm:53 {
     bind 127.0.1.1
@@ -132,7 +137,7 @@ cat > dnsentries.db << EOF
                                 1209600    ; expire (2 weeks)
                                 3600       ; minimum (1 hour)
                                 )
-spire-server.spire.docker.nsm   IN      A    ${ipdock}
+spire-server.spire   IN      A    ${ipdock}
 EOF
 ```
 

--- a/examples/k8s_monolith/external_nse/dns/README.md
+++ b/examples/k8s_monolith/external_nse/dns/README.md
@@ -81,13 +81,13 @@ kubectl rollout restart -n kube-system deployment/coredns
 
 Save the initial `resolv.conf` in a separate file:
 ```bash
-docker exec -d -i nse-simple-vl3-docker cp /etc/resolv.conf /etc/resolv_init.conf
+docker exec nse-simple-vl3-docker cp /etc/resolv.conf /etc/resolv_init.conf
 ```
 
 Add an entry to `resolv.conf` with a coredns address.
 Use a custom address to reduce the chance of it being used (default is 127.0.0.1)
 ```bash
-docker exec -d -i nse-simple-vl3-docker sh -c "echo 'nameserver 127.0.1.1' > /etc/resolv.conf"
+docker exec nse-simple-vl3-docker sh -c "echo 'nameserver 127.0.1.1' > /etc/resolv.conf"
 ```
 
 Create coredns config file:
@@ -98,12 +98,17 @@ cat > coredns-config << EOF
     log
     errors
     ready
-    file dnsentries.db
     forward . /etc/resolv_init.conf {
         max_concurrent 1000
     }
     loop
     reload 5s
+}
+docker.nsm:53 {
+    bind 127.0.1.1
+    log
+    errors
+    file dnsentries.db
 }
 k8s.nsm:53 {
     bind 127.0.1.1
@@ -126,7 +131,7 @@ cat > dnsentries.db << EOF
                                 1209600    ; expire (2 weeks)
                                 3600       ; minimum (1 hour)
                                 )
-spire-server.spire.docker.nsm   IN      A    ${ipdock}
+spire-server.spire   IN      A    ${ipdock}
 EOF
 ```
 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We shouldn't run `docker exec` command in the background for these cases

The dns configuration has also been fixed, since `file` and `forward` plugins cannot be located on the same server.

## Issue link
Closes: https://github.com/networkservicemesh/deployments-k8s/issues/11229


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
