### PR TITLE
Update env vars of registry-memory

### DIFF
--- a/apps/registry-memory/registry-memory.yaml
+++ b/apps/registry-memory/registry-memory.yaml
@@ -20,11 +20,11 @@ spec:
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
-            - name: REGISTRY_MEMORY_LISTEN_ON
+            - name: NSM_LISTEN_ON
               value: tcp://:5002
-            - name: REGISTRY_MEMORY_LOG_LEVEL
+            - name: NSM_LOG_LEVEL
               value: TRACE
-            - name: REGISTRY_MEMORY_PROXY_REGISTRY_URL
+            - name: NSM_PROXY_REGISTRY_URL
               value: nsmgr-proxy:5004
           imagePullPolicy: IfNotPresent
           name: registry


### PR DESCRIPTION
## Description
The prefix used in `cmd-registry-memory` for `envconfig.Usage` got changed to 'nsm', so I'm updating this too.


## Issue link
[ Keep env var descriptions in sync in cmd and README.md #65 ](https://github.com/networkservicemesh/.github/issues/65)


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ x ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ x ] Refactoring
- [ x ] CI
