### PR TITLE
Align env vars

### DIFF
--- a/apps/nsc-vfio/nsc.yaml
+++ b/apps/nsc-vfio/nsc.yaml
@@ -41,7 +41,7 @@ spec:
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_NETWORK_SERVICES
               value: vfio://pingpong?sriovToken=worker.domain/10G
-            - name: NSM_LIVENESSCHECKENABLED
+            - name: NSM_LIVENESS_CHECK_ENABLED
               value: "false"
           volumeMounts:
             - name: spire-agent-socket

--- a/apps/nsmgr-proxy/nsmgr-proxy.yaml
+++ b/apps/nsmgr-proxy/nsmgr-proxy.yaml
@@ -60,9 +60,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: map-ip-k8s
           env:
-            - name: NSM_OUTPUTPATH
+            - name: NSM_OUTPUT_PATH
               value: "/etc/mapip/config.yaml"
-            - name: NSM_NODENAME
+            - name: NSM_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName

--- a/examples/heal_extended/component-restart/client-cp.yaml
+++ b/examples/heal_extended/component-restart/client-cp.yaml
@@ -26,7 +26,7 @@ spec:
           value: "2m"
         - name: NSM_REQUEST_TIMEOUT
           value: "5s"
-        - name: NSM_LIVENESSCHECKENABLED
+        - name: NSM_LIVENESS_CHECK_ENABLED
           value: "false"
       volumeMounts:
         - name: spire-agent-socket

--- a/examples/pss/nsm-system/patch-admission-webhook-k8s.yaml
+++ b/examples/pss/nsm-system/patch-admission-webhook-k8s.yaml
@@ -10,4 +10,4 @@ spec:
         - name: admission-webhook-k8s
           env:
             - name: NSM_ENVS
-              value: NSM_LOG_LEVEL=TRACE,NSM_LOCALDNSSERVERENABLED=False
+              value: NSM_LOG_LEVEL=TRACE,NSM_LOCAL_DNS_SERVER_ENABLED=False


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
I've put the split_words:"true" to some env vars, as discussed, so there was a need to change 
the envs here too. Now when doing the pull request I've discovered that I've updated some of the deprecated repos too, so some of the envs below might not be relevant, haven't double checked it yet.

NSM_ACL_CONFIG
NSM_BRIDGE_NAME
NSM_FEDERATES_WITH
NSM_INTERFACE_NAME
NSM_LIVENESS_CHECK_ENABLED
NSM_LIVENESS_CHECK_INTERVAL
NSM_LIVENESS_CHECK_TIMEOUT
NSM_LOCAL_DNS_SERVER_ADDRESS
NSM_LOCAL_DNS_SERVER_ENABLED
NSM_METRICS_EXPORT_INTERVAL
NSM_NODE_NAME
NSM_OPEN_TELEMETRY_ENDPOINT
NSM_OUTPUT_PATH
NSM_TRUST_DOMAIN
NSM_VL3_PREFIX


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ x ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ x ] CI
