### PR TITLE
Fix envs in cmd-nsmgr, cmd-forwarder-vpp and cmd-registry

### DIFF
--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -38,9 +38,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: NSM_PPROF_ENABLED
-              value: true
+              value: "true"
             - name: NSM_PPROF_PORT
-              value: 6060
+              value: "6060"
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -33,9 +33,9 @@ spec:
             - name: NSM_LOG_LEVEL
               value: TRACE
             - name: NSM_PPROF_ENABLED
-              value: true
+              value: "true"
             - name: NSM_PPROF_PORT
-              value: 6060
+              value: "6060"
             - name: NSM_REGISTRY_URL
               value: "registry:5002"
             #            - name: DLV_LISTEN_NSMGR

--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -32,9 +32,9 @@ spec:
             - name: NSM_PROXY_REGISTRY_URL
               value: nsmgr-proxy:5004
             - name: NSM_PPROF_ENABLED
-              value: true
+              value: "true"
             - name: NSM_PPROF_PORT
-              value: 6060
+              value: "6060"
           imagePullPolicy: IfNotPresent
           name: registry
           ports:


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Envs should all be strings only. 

## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/pull/1026

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
