### PR TITLE
Rename NSM_PPROF_PORT env to NSM_PPROF_LISTEN_ON and update value

### DIFF
--- a/.github/workflows/check-tag.yaml
+++ b/.github/workflows/check-tag.yaml
@@ -81,7 +81,9 @@ jobs:
 
     - name: Replace pprof enabled value with false
       run: |
-        grep 'NSM_PPROF_ENABLED' -rl * | xargs sed -i '/name: NSM_PPROF_ENABLED/{ n; s/value: .*/value: false/g }'
+        grep 'NSM_PPROF_ENABLED' -rl * | xargs sed -i '/name: NSM_PPROF_ENABLED/{ n; s/value: .*/value: "false"/g }'
+        grep 'NSM_PPROF_ENABLED' -rl * | xargs sed -i 's/NSM_PPROF_ENABLED: .*/NSM_PPROF_ENABLED: "false"/g'
+        grep 'NSM_PPROF_ENABLED' -rl * | xargs sed -i 's/NSM_PPROF_ENABLED=true/NSM_PPROF_ENABLED=false/g'
 
         git add -- .
         git commit -s -m "Replace pprof enabled value with false"

--- a/apps/forwarder-vpp/forwarder.yaml
+++ b/apps/forwarder-vpp/forwarder.yaml
@@ -39,8 +39,8 @@ spec:
                   fieldPath: metadata.name
             - name: NSM_PPROF_ENABLED
               value: "true"
-            - name: NSM_PPROF_PORT
-              value: "6060"
+            - name: NSM_PPROF_LISTEN_ON
+              value: "localhost:6060"
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/apps/nsmgr/nsmgr.yaml
+++ b/apps/nsmgr/nsmgr.yaml
@@ -34,8 +34,8 @@ spec:
               value: TRACE
             - name: NSM_PPROF_ENABLED
               value: "true"
-            - name: NSM_PPROF_PORT
-              value: "6060"
+            - name: NSM_PPROF_LISTEN_ON
+              value: "localhost:6060"
             - name: NSM_REGISTRY_URL
               value: "registry:5002"
             #            - name: DLV_LISTEN_NSMGR

--- a/apps/registry-k8s/registry-k8s.yaml
+++ b/apps/registry-k8s/registry-k8s.yaml
@@ -33,8 +33,8 @@ spec:
               value: nsmgr-proxy:5004
             - name: NSM_PPROF_ENABLED
               value: "true"
-            - name: NSM_PPROF_PORT
-              value: "6060"
+            - name: NSM_PPROF_LISTEN_ON
+              value: "localhost:6060"
           imagePullPolicy: IfNotPresent
           name: registry
           ports:


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Added configuration for turning profiling on/off.


## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/12045


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
