### PR TITLE
Add PostgreSQL server to the spire server config and get rid of using persistent volume - interdomain tests

### DIFF
--- a/examples/spire/cluster1/kustomization.yaml
+++ b/examples/spire/cluster1/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: spire
 
 resources:
 - ../base
+- ../postgres
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/examples/spire/cluster1/server.conf
+++ b/examples/spire/cluster1/server.conf
@@ -36,8 +36,8 @@ server {
 plugins {
     DataStore "sql" {
         plugin_data {
-            database_type = "sqlite3"
-            connection_string = "/run/spire/data/datastore.sqlite3"
+            database_type = "postgres"
+            connection_string = "dbname=spire user=admin password=admin host=spire-postgres.spire port=5432 sslmode=disable"
         }
     }
     NodeAttestor "k8s_psat" {

--- a/examples/spire/cluster2/kustomization.yaml
+++ b/examples/spire/cluster2/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: spire
 
 resources:
 - ../base
+- ../postgres
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/examples/spire/cluster2/server.conf
+++ b/examples/spire/cluster2/server.conf
@@ -36,8 +36,8 @@ server {
 plugins {
     DataStore "sql" {
         plugin_data {
-            database_type = "sqlite3"
-            connection_string = "/run/spire/data/datastore.sqlite3"
+            database_type = "postgres"
+            connection_string = "dbname=spire user=admin password=admin host=spire-postgres.spire port=5432 sslmode=disable"
         }
     }
     NodeAttestor "k8s_psat" {

--- a/examples/spire/cluster3/kustomization.yaml
+++ b/examples/spire/cluster3/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: spire
 
 resources:
 - ../base
+- ../postgres
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/examples/spire/cluster3/server.conf
+++ b/examples/spire/cluster3/server.conf
@@ -36,8 +36,8 @@ server {
 plugins {
     DataStore "sql" {
         plugin_data {
-            database_type = "sqlite3"
-            connection_string = "/run/spire/data/datastore.sqlite3"
+            database_type = "postgres"
+            connection_string = "dbname=spire user=admin password=admin host=spire-postgres.spire port=5432 sslmode=disable"
         }
     }
     NodeAttestor "k8s_psat" {


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Extended config for interdomain tests. Main PR - https://github.com/networkservicemesh/deployments-k8s/pull/12120


## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/12072


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
