### PR TITLE
[qfix] remove unnecessary `namespace` field in admission-webhook's `kustomization.yaml`

### DIFF
--- a/apps/admission-webhook-k8s/kustomization.yaml
+++ b/apps/admission-webhook-k8s/kustomization.yaml
@@ -9,5 +9,3 @@ resources:
 - binding.yaml
 - role.yaml
 - mutating-webhook-config.yaml
-
-namespace: default


### PR DESCRIPTION
## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [x] Refactoring
- [ ] CI
