### PR TITLE
Update README.md to included -c flag

### DIFF
--- a/examples/interdomain/three_cluster_configuration/spiffe_federation/README.md
+++ b/examples/interdomain/three_cluster_configuration/spiffe_federation/README.md
@@ -11,27 +11,27 @@ Once federation is bootstrapped, the trust bundle updates are fetched through th
 
 Get and store bundles for clusters:
 ```bash
-bundle1=$(kubectl --kubeconfig=$KUBECONFIG1 exec spire-server-0 -n spire -- bin/spire-server bundle show -format spiffe)
-bundle2=$(kubectl --kubeconfig=$KUBECONFIG2 exec spire-server-0 -n spire -- bin/spire-server bundle show -format spiffe)
-bundle3=$(kubectl --kubeconfig=$KUBECONFIG3 exec spire-server-0 -n spire -- bin/spire-server bundle show -format spiffe)
+bundle1=$(kubectl --kubeconfig=$KUBECONFIG1 exec spire-server-0 -n spire -c spire-server  -- bin/spire-server bundle show -format spiffe)
+bundle2=$(kubectl --kubeconfig=$KUBECONFIG2 exec spire-server-0 -n spire -c spire-server  -- bin/spire-server bundle show -format spiffe)
+bundle3=$(kubectl --kubeconfig=$KUBECONFIG3 exec spire-server-0 -n spire -c spire-server  -- bin/spire-server bundle show -format spiffe)
 ```
 
 Set bundles for the first cluster:
 ```bash
-echo $bundle2 | kubectl --kubeconfig=$KUBECONFIG1 exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster2"
-echo $bundle3 | kubectl --kubeconfig=$KUBECONFIG1 exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster3"
+echo $bundle2 | kubectl --kubeconfig=$KUBECONFIG1 exec -i spire-server-0 -n spire -c spire-server -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster2"
+echo $bundle3 | kubectl --kubeconfig=$KUBECONFIG1 exec -i spire-server-0 -n spire -c spire-server -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster3"
 ```
 
 Set bundles for the second cluster:
 ```bash
-echo $bundle1 | kubectl --kubeconfig=$KUBECONFIG2 exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster1"
-echo $bundle3 | kubectl --kubeconfig=$KUBECONFIG2 exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster3"
+echo $bundle1 | kubectl --kubeconfig=$KUBECONFIG2 exec -i spire-server-0 -n spire -c spire-server -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster1"
+echo $bundle3 | kubectl --kubeconfig=$KUBECONFIG2 exec -i spire-server-0 -n spire -c spire-server -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster3"
 ```
 
 Set bundles for the third cluster:
 ```bash
-echo $bundle1 | kubectl --kubeconfig=$KUBECONFIG3 exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster1"
-echo $bundle2 | kubectl --kubeconfig=$KUBECONFIG3 exec -i spire-server-0 -n spire -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster2"
+echo $bundle1 | kubectl --kubeconfig=$KUBECONFIG3 exec -i spire-server-0 -n spire -c spire-server -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster1"
+echo $bundle2 | kubectl --kubeconfig=$KUBECONFIG3 exec -i spire-server-0 -n spire -c spire-server -- bin/spire-server bundle set -format spiffe -id "spiffe://nsm.cluster2"
 ```
 
 ## Cleanup


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

The -c flag in the kubectl exec command specifies which container in a pod you want to execute the command against. This is necessary when a pod has multiple containers, and you need to indicate which container should run the command.

If the -c flag is not passed, the command is executed, however a messagem is popupd, and in automated scripts it invalidade the processo.

The adition of -c will not affect the manual usage and will prevent erros in some automation process.

Summary
Use -c when the pod has multiple containers.
It ensures you are executing the command in the correct container. Helps avoid unexpected behavior or errors when Kubernetes defaults to the wrong container.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [x] Documentation
- [ ] Refactoring
- [ ] CI
