### PR TITLE
Fix ipam policies ping command

### DIFF
--- a/examples/features/ipam-policies/README.md
+++ b/examples/features/ipam-policies/README.md
@@ -33,7 +33,7 @@ kubectl wait --for=condition=ready --timeout=1m pod -l app=first-nse -n ns-ipam-
 
 Ping the first NSE from the first client:
 ```bash
-kubectl exec pods/alpine-1 -n ns-ipam-policies -- ping -c 4 172.16.1.0 || kubectl exec pods/alpine-2 -n ns-ipam-policies -- ping -c 4 172.16.1.2
+kubectl exec pods/alpine-1 -n ns-ipam-policies -- ping -c 4 172.16.1.0 || kubectl exec pods/alpine-1 -n ns-ipam-policies -- ping -c 4 172.16.1.2
 ```
 
 Ping the first NSE from the second client:


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Test have been failing in case first client had 172.16.1.2 as dst. It is expected to ping here from alpine-1 pod to check both addresses - one is acceptable for the first client, the other for second. 


## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/1042


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [x] CI
