### PR TITLE
qfix failing memif to kernel tests

### DIFF
--- a/examples/use-cases/Memif2Ethernet2Kernel/kustomization.yaml
+++ b/examples/use-cases/Memif2Ethernet2Kernel/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - ns-memif2ethernet2kernel.yaml
 - netsvc.yaml
 - ../../../apps/nsc-memif
-- ../../../apps/nse-kernel
+- nse-kernel.yaml
 
 patches:
 - path: patch-nsc.yaml

--- a/examples/use-cases/Memif2Ethernet2Kernel/nse-kernel.yaml
+++ b/examples/use-cases/Memif2Ethernet2Kernel/nse-kernel.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+  labels:
+    app: nse-kernel
+spec:
+  selector:
+    matchLabels:
+      app: nse-kernel
+  template:
+    metadata:
+      labels:
+        app: nse-kernel
+        "spiffe.io/spiffe-id": "true"
+    spec:
+      containers:
+        - name: nse
+          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:5095291
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_NAME
+              value: "$(POD_NAME)"
+            - name: NSM_LOG_LEVEL
+              value: TRACE
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 40Mi
+            limits:
+              memory: 80Mi
+              cpu: 200m
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate
+

--- a/examples/use-cases/Memif2IP2Kernel/kustomization.yaml
+++ b/examples/use-cases/Memif2IP2Kernel/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - ns-memif2ip2kernel.yaml
 - netsvc.yaml
 - ../../../apps/nsc-memif
-- ../../../apps/nse-kernel
+- nse-kernel.yaml
 
 patches:
 - path: patch-nsc.yaml

--- a/examples/use-cases/Memif2IP2Kernel/nse-kernel.yaml
+++ b/examples/use-cases/Memif2IP2Kernel/nse-kernel.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+  labels:
+    app: nse-kernel
+spec:
+  selector:
+    matchLabels:
+      app: nse-kernel
+  template:
+    metadata:
+      labels:
+        app: nse-kernel
+        "spiffe.io/spiffe-id": "true"
+    spec:
+      containers:
+        - name: nse
+          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:5095291
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_NAME
+              value: "$(POD_NAME)"
+            - name: NSM_LOG_LEVEL
+              value: TRACE
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 40Mi
+            limits:
+              memory: 80Mi
+              cpu: 200m
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate
+

--- a/examples/use-cases/Memif2Kernel/kustomization.yaml
+++ b/examples/use-cases/Memif2Kernel/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - ns-memif2kernel.yaml
 - netsvc.yaml
 - ../../../apps/nsc-memif
-- ../../../apps/nse-kernel
+- nse-kernel.yaml
 
 patches:
 - path: patch-nsc.yaml

--- a/examples/use-cases/Memif2Kernel/nse-kernel.yaml
+++ b/examples/use-cases/Memif2Kernel/nse-kernel.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-kernel
+  labels:
+    app: nse-kernel
+spec:
+  selector:
+    matchLabels:
+      app: nse-kernel
+  template:
+    metadata:
+      labels:
+        app: nse-kernel
+        "spiffe.io/spiffe-id": "true"
+    spec:
+      containers:
+        - name: nse
+          image: ghcr.io/networkservicemesh/ci/cmd-nse-icmp-responder:5095291
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_NAME
+              value: "$(POD_NAME)"
+            - name: NSM_LOG_LEVEL
+              value: TRACE
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 40Mi
+            limits:
+              memory: 80Mi
+              cpu: 200m
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate
+


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Policy Base Routing was not implemented in memif use case. Now using nse-kernel pod without PBR config. 


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [x] CI
