### PR TITLE
Add Kuma image to the external images

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -22,3 +22,4 @@ images:
   - prom/prometheus:v2.37.0
   - networkstatic/iperf3:latest
   - hashicorp/http-echo:1.0
+  - docker.io/kumahq/kuma-dp:1.7.0-amd64


### PR DESCRIPTION
Adds the Kuma image to `external-images.yaml` to prevent test timeouts from image pulling.