### PR TITLE
Fix redis container crash by adding retry logic to postStart hook

### DIFF
--- a/examples/interdomain/usecases/nsm_kuma_universal_vl3/demo-redis.yaml
+++ b/examples/interdomain/usecases/nsm_kuma_universal_vl3/demo-redis.yaml
@@ -61,7 +61,8 @@ spec:
                 command: ["/bin/sleep", "30"]
             postStart:
               exec:
-                command: ["/usr/local/bin/redis-cli", "set", "zone", "local"]
+                command:
+                  ["/bin/sh", "-c", "for i in $(seq 1 10); do /usr/local/bin/redis-cli set zone local && exit 0 || sleep 1; done; exit 1"]
         - args:
           - run
           - --cp-address=https://control-plane-kuma.my-vl3-network:5678/


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
The Redis container was crashing due to the `postStart` lifecycle hook failing. This happened because the `redis-cli` command attempted to run before the Redis server was fully ready to accept connections.

To address this, a retry loop was added to the `postStart` hook, which allows up to 10 attempts (with 1-second intervals) for the `redis-cli` command to succeed, ensuring the container doesn't enter a `CrashLoopBackOff` state due to premature `postStart` execution.


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
