### PR TITLE
Remove spire from ignoreNamespaces in spire-controller-manager-config

### DIFF
--- a/examples/spire/single_cluster/spire-controller-manager-config.yaml
+++ b/examples/spire/single_cluster/spire-controller-manager-config.yaml
@@ -21,5 +21,4 @@ spireServerSocketPath: /run/spire/sockets/api.sock
 ignoreNamespaces:
   - kube-system
   - kube-public
-  - spire
   - local-path-storage


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
It seems that spire-controller-manager 0.6.2 does not use exact match for ignoring namespaces but checks if the word is included and ignoring the matching namespaces. Therefore I removed "spire" from the configuration since it prevented pods in namespaces containing the word "spire" to get SVIDs because the pods have not been registered.

## Issue
https://github.com/networkservicemesh/deployments-k8s/issues/13477

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI